### PR TITLE
Add 'Top level Category' to data in Confirmation email

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTypeConstants.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTypeConstants.java
@@ -10,7 +10,8 @@ public enum CategoryTypeConstants {
     OTHER("*"),
     SCOTTISH_LIMITED_PARTNERSHIP("SLP"),
     SCOTTISH_QUALIFYING_PARTNERSHIP("SQP"),
-    SHARE_CAPITAL("SH");
+    SHARE_CAPITAL("SH"),
+    REGISTRAR_POWERS("RP");
 
     CategoryTypeConstants(final String value) {
         this.value = value;

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/ExternalConfirmationEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/ExternalConfirmationEmailData.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.efs.api.email.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Objects;
+import uk.gov.companieshouse.efs.api.categorytemplates.model.CategoryTypeConstants;
 import uk.gov.companieshouse.efs.api.submissions.model.Company;
 import uk.gov.companieshouse.efs.api.submissions.model.Presenter;
 
@@ -18,18 +19,21 @@ public class ExternalConfirmationEmailData {
     private Company company;
     @JsonProperty("form_type")
     private String formType;
+    @JsonProperty("top_level_category")
+    private CategoryTypeConstants topLevelCategory;
     @JsonProperty("email_file_details_list")
     private List<EmailFileDetails> emailFileDetailsList;
 
     public ExternalConfirmationEmailData(String to, String subject, String confirmationReference,
                                          Presenter presenter, Company company, String formType,
-                                         List<EmailFileDetails> emailFileDetailsList) {
+                                         CategoryTypeConstants topLevelCategory, List<EmailFileDetails> emailFileDetailsList) {
         this.to = to;
         this.subject = subject;
         this.confirmationReference = confirmationReference;
         this.presenter = presenter;
         this.company = company;
         this.formType = formType;
+        this.topLevelCategory = topLevelCategory;
         this.emailFileDetailsList = emailFileDetailsList;
     }
 
@@ -81,6 +85,14 @@ public class ExternalConfirmationEmailData {
         this.formType = formType;
     }
 
+    public CategoryTypeConstants getTopLevelCategory() {
+        return topLevelCategory;
+    }
+
+    public void setTopLevelCategory(final CategoryTypeConstants topLevelCategory) {
+        this.topLevelCategory = topLevelCategory;
+    }
+
     public List<EmailFileDetails> getEmailFileDetailsList() {
         return emailFileDetailsList;
     }
@@ -104,6 +116,7 @@ public class ExternalConfirmationEmailData {
                    .equals(getPresenter(), that.getPresenter()) && Objects
                    .equals(getCompany(), that.getCompany()) && Objects
                    .equals(getFormType(), that.getFormType()) && Objects
+                   .equals(getTopLevelCategory(), that.getTopLevelCategory())  && Objects
                    .equals(getEmailFileDetailsList(), that.getEmailFileDetailsList());
     }
 
@@ -111,7 +124,7 @@ public class ExternalConfirmationEmailData {
     public int hashCode() {
         return Objects
             .hash(getTo(), getSubject(), getConfirmationReference(), getPresenter(), getCompany(),
-                getFormType(), getEmailFileDetailsList());
+                getFormType(), getTopLevelCategory(), getEmailFileDetailsList());
     }
 
     public static ExternalConfirmationEmailData.Builder builder() {
@@ -126,6 +139,7 @@ public class ExternalConfirmationEmailData {
         private Presenter presenter;
         private Company company;
         private String formType;
+        private CategoryTypeConstants topLevelCategory;
         private List<EmailFileDetails> emailFileDetailsList;
 
         public ExternalConfirmationEmailData.Builder withTo(String to) {
@@ -158,6 +172,12 @@ public class ExternalConfirmationEmailData {
             return this;
         }
 
+        public ExternalConfirmationEmailData.Builder withTopLevelCategory(
+            CategoryTypeConstants topLevelCategory) {
+            this.topLevelCategory = topLevelCategory;
+            return this;
+        }
+
         public ExternalConfirmationEmailData.Builder withEmailFileDetailsList(List<EmailFileDetails> emailFileDetailsList) {
             this.emailFileDetailsList = emailFileDetailsList;
             return this;
@@ -165,7 +185,7 @@ public class ExternalConfirmationEmailData {
 
         public ExternalConfirmationEmailData build() {
             return new ExternalConfirmationEmailData(to, subject, confirmationReference, presenter, company, formType,
-                    emailFileDetailsList);
+                    topLevelCategory, emailFileDetailsList);
         }
 
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
@@ -128,7 +128,7 @@ class CategoryTemplateServiceImplTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"RP,'','',RP", "CC,'','',CC", "IA1986,INS,'',INS"})
+    @CsvSource({"DUMMY,'','',OTHER", "RP,'','',RP", "CC,'','',CC", "IA1986,INS,'',INS"})
     void getTopLevelCategory(final String category, final String parent, final String grandParent,
         final String result) {
         //given

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
@@ -128,7 +128,7 @@ class CategoryTemplateServiceImplTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"RP,'','',OTHER", "CC,'','',CC", "IA1986,INS,'',INS"})
+    @CsvSource({"RP,'','',RP", "CC,'','',CC", "IA1986,INS,'',INS"})
     void getTopLevelCategory(final String category, final String parent, final String grandParent,
         final String result) {
         //given

--- a/src/test/java/uk/gov/companieshouse/efs/api/config/ConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/config/ConfigTest.java
@@ -62,7 +62,7 @@ class ConfigTest {
     void emailMapperFactory() {
         final ExternalAcceptEmailMapper acceptEmailMapper = new ExternalAcceptEmailMapper(null, null, null);
         final ExternalConfirmationEmailMapper confirmationMapper =
-            new ExternalConfirmationEmailMapper(null, null, null);
+            new ExternalConfirmationEmailMapper(null, null, null, null, null);
         final ExternalRejectEmailMapper rejectMapper = new ExternalRejectEmailMapper(null, null, null);
         final ExternalEmailMapperFactory externalMapperFactory =
             new ExternalEmailMapperFactory(acceptEmailMapper, confirmationMapper, rejectMapper);

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/ExternalConfirmationEmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/ExternalConfirmationEmailMapperTest.java
@@ -7,18 +7,20 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.Collections;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
+import uk.gov.companieshouse.efs.api.categorytemplates.model.CategoryTypeConstants;
+import uk.gov.companieshouse.efs.api.categorytemplates.service.CategoryTemplateService;
 import uk.gov.companieshouse.efs.api.email.config.ExternalConfirmationEmailConfig;
 import uk.gov.companieshouse.efs.api.email.model.EmailDocument;
 import uk.gov.companieshouse.efs.api.email.model.EmailFileDetails;
 import uk.gov.companieshouse.efs.api.email.model.ExternalConfirmationEmailData;
 import uk.gov.companieshouse.efs.api.email.model.ExternalConfirmationEmailModel;
+import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.efs.api.submissions.model.Company;
 import uk.gov.companieshouse.efs.api.submissions.model.FileDetails;
 import uk.gov.companieshouse.efs.api.submissions.model.FormDetails;
@@ -59,9 +61,19 @@ public class ExternalConfirmationEmailMapperTest {
     @Mock
     private Presenter presenter;
 
+    @Mock
+    private CategoryTemplateService categoryTemplateService;
+
+    @Mock
+    private FormTemplateService formTemplateService;
+
+    @Mock
+    private FormTemplateApi formTemplateApi;
+
     @BeforeEach
     void setUp() {
-        this.confirmationEmailMapper = new ExternalConfirmationEmailMapper(config, idGenerator, timestampGenerator);
+        this.confirmationEmailMapper = new ExternalConfirmationEmailMapper(config, idGenerator, timestampGenerator,
+            categoryTemplateService, formTemplateService);
     }
 
     @Test
@@ -89,6 +101,9 @@ public class ExternalConfirmationEmailMapperTest {
         when(formDetails.getFileDetailsList()).thenReturn(Collections.singletonList(fileDetails));
 
         when(externalConfirmationEmailModel.getSubmission()).thenReturn(submission);
+        when(formTemplateService.getFormTemplate("SH01")).thenReturn(formTemplateApi);
+        when(formTemplateApi.getFormCategory()).thenReturn("SH");
+        when(categoryTemplateService.getTopLevelCategory("SH")).thenReturn(CategoryTypeConstants.SHARE_CAPITAL);
 
         //when
         EmailDocument<ExternalConfirmationEmailData> actual = confirmationEmailMapper.map(externalConfirmationEmailModel);
@@ -113,6 +128,7 @@ public class ExternalConfirmationEmailMapperTest {
                                 .withSubject("Your document has been submitted")
                                 .withCompany(company)
                                 .withFormType("SH01")
+                                .withTopLevelCategory(CategoryTypeConstants.SHARE_CAPITAL)
                                 .withConfirmationReference("abcd3434343efsfg")
                                 .withEmailFileDetailsList(Collections.singletonList(new EmailFileDetails(fileDetails, null)))
                                 .withPresenter(presenter)


### PR DESCRIPTION
Registrar Powers forms that are accepted will be followed up with a letter to explain what happens next.
This needs to be reflected in the confirmation email text.

PR for email templates - https://github.com/companieshouse/chs-notification-api/pull/233

BI-5556

Unit tests updated ✔️ 