### PR TITLE
Fix Submissions appearing on more than one payment report

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
@@ -107,8 +107,9 @@ public class PaymentReportServiceImpl implements PaymentReportService {
     }
 
     private List<PaymentTransaction> findPaymentTransactions(ImmutableSet<SubmissionStatus> statuses) {
-        final List<Submission> submissions =
-            repository.findPaidSubmissions(statuses, LocalDate.now(clock).minusDays(reportPeriodDaysBeforeToday));
+        final LocalDate endDate = LocalDate.now(clock);
+        final LocalDate startDate = endDate.minusDays(reportPeriodDaysBeforeToday);
+        final List<Submission> submissions = repository.findPaidSubmissions(statuses, startDate, endDate);
 
         return submissions.stream().map(paymentReportMapper::map).collect(Collectors.toList());
     }

--- a/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
@@ -107,8 +107,8 @@ public class PaymentReportServiceImpl implements PaymentReportService {
     }
 
     private List<PaymentTransaction> findPaymentTransactions(ImmutableSet<SubmissionStatus> statuses) {
-        final LocalDate endDate = LocalDate.now(clock);
-        final LocalDate startDate = endDate.minusDays(reportPeriodDaysBeforeToday);
+        final LocalDate startDate = LocalDate.now(clock).minusDays(reportPeriodDaysBeforeToday);
+        final LocalDate endDate = startDate.plusDays((1)); // report period should be 1 day long
         final List<Submission> submissions = repository.findPaidSubmissions(statuses, startDate, endDate);
 
         return submissions.stream().map(paymentReportMapper::map).collect(Collectors.toList());

--- a/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
@@ -108,7 +108,7 @@ public class PaymentReportServiceImpl implements PaymentReportService {
 
     private List<PaymentTransaction> findPaymentTransactions(ImmutableSet<SubmissionStatus> statuses) {
         final LocalDate startDate = LocalDate.now(clock).minusDays(reportPeriodDaysBeforeToday);
-        final LocalDate endDate = startDate.plusDays((1)); // report period should be 1 day long
+        final LocalDate endDate = startDate.plusDays(1); // report period should be 1 day long
         final List<Submission> submissions = repository.findPaidSubmissions(statuses, startDate, endDate);
 
         return submissions.stream().map(paymentReportMapper::map).collect(Collectors.toList());

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepository.java
@@ -28,6 +28,15 @@ public interface SubmissionRepository {
 
     List<Submission> findDelayedSubmissions(SubmissionStatus status, LocalDateTime before);
 
-    List<Submission> findPaidSubmissions(Collection<SubmissionStatus> statuses, LocalDate submitDate);
+    /**
+     * Find paid submissions having any of the given statuses and submit date between startDate and endDate.
+     *
+     * @param statuses  the statuses to include
+     * @param startDate the report period start (inclusive)
+     * @param endDate   the report period end (exclusive)
+     * @return the collection of submissions (may be empty)
+     */
+    List<Submission> findPaidSubmissions(Collection<SubmissionStatus> statuses, LocalDate startDate,
+        final LocalDate endDate);
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
@@ -121,17 +121,17 @@ public class SubmissionRepositoryImpl implements SubmissionRepository {
     }
 
     @Override
-    public List<Submission> findPaidSubmissions(final Collection<SubmissionStatus> statuses, final LocalDate submitDate) {
-        LOGGER.debug(String.format("Fetching paid submissions with statuses: [%s] and submitted on [%s]", statuses,
-            submitDate.toString()));
-        LocalDate periodEnd = submitDate.plusDays(1);
-        LocalDate periodStart = submitDate.minusDays(1);
+    public List<Submission> findPaidSubmissions(final Collection<SubmissionStatus> statuses, final LocalDate startDate,
+        final LocalDate endDate) {
+        LOGGER.debug(String
+            .format("Fetching paid submissions with statuses: [%s] and submitted between [%s] and [%s] (exclusive)",
+                statuses, startDate.toString(), endDate.toString()));
         List<Submission> submissions = template.find(Query.query(
-            Criteria.where(STATUS).in(statuses).and(SUBMITTED_AT).gt(periodStart).lt(periodEnd).and(FEE_ON_SUBMISSION)
+            Criteria.where(STATUS).in(statuses).and(SUBMITTED_AT).gte(startDate).lt(endDate).and(FEE_ON_SUBMISSION)
                 .exists(true)), Submission.class, SUBMISSIONS_COLLECTION);
         LOGGER.debug(String
-            .format("Found [%d] paid submissions with statuses: [%s] and submitted on  [%s]", submissions.size(),
-                statuses, submitDate.toString()));
+            .format("Found [%d] paid submissions with statuses: [%s] and submitted [%s] and [%s] (exclusive)",
+                submissions.size(), statuses, startDate.toString(), endDate.toString()));
         return submissions;
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImplTest.java
@@ -47,8 +47,8 @@ import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository
 
 @ExtendWith(MockitoExtension.class)
 class PaymentReportServiceImplTest {
-    private static final LocalDate REPORT_DATE = LocalDate.of(2020, 8, 31);
-    private static final LocalTime NOW_TIME = LocalTime.of(10, 8, 42);
+    private static final LocalDate TEST_DATE = LocalDate.of(2020, 8, 31);
+    private static final LocalTime NOW_TIME = LocalTime.of(1, 1, 1);
     private static final FormDetails FORM_SCOT_FEE = new FormDetails(null, "SQP1", null);
     private static final FormDetails FORM_NON_SCOT_FEE = new FormDetails(null, "CS01", null);
     private static final String REPORT_SCOT = "'EFS_ScottishPaymentTransactions_'yyyy-MM-dd'.csv'";
@@ -62,7 +62,7 @@ class PaymentReportServiceImplTest {
             + "FAILED_FEE,REF_FF,presenter@nomail.net,2020-08-31T13:13:13,10,PAY_FF,CS01,00000000\n";
 
 
-    private PaymentReportServiceImpl spyService;
+    private PaymentReportServiceImpl testService;
 
     @Mock
     private EmailService emailService;
@@ -81,21 +81,12 @@ class PaymentReportServiceImplTest {
 
     private Submission submissionSF;
     private Submission submissionSFF;
-    private Submission submissionNSF;
+    private Submission submissionOSF;
     private Submission submissionNSFF;
 
     @BeforeEach
     void setUp() {
-        final Clock clock =
-            Clock.fixed(REPORT_DATE.plusDays(1).atTime(NOW_TIME).toInstant(ZoneOffset.UTC), ZoneOffset.UTC);
-
-        spyService = spy(new PaymentReportServiceImpl(emailService,
-            new ReportQueryServiceImpl(submissionRepository, reportMapper), outputStreamWriterFactory, s3ClientService,
-            clock, BUCKET_NAME));
-        ReflectionTestUtils.setField(spyService, "scotlandReportPattern", REPORT_SCOT);
-        ReflectionTestUtils.setField(spyService, "scotlandForms", SCOT_FORM_LIST);
-        ReflectionTestUtils.setField(spyService, "failedTransactionsFinanceReportPattern", REPORT_FAILED);
-        ReflectionTestUtils.setField(spyService, "reportPeriodDaysBeforeToday", 1);
+        testService = createTestServiceSpy(1);
 
         final Company company = new Company("00000000", "Testing Services");
         final Presenter presenter = new Presenter("presenter@nomail.net");
@@ -103,40 +94,49 @@ class PaymentReportServiceImplTest {
 
         submissionSF = builder.withId("SCOT_FEE").withCompany(company).withFormDetails(FORM_SCOT_FEE)
             .withConfirmationReference("REF_SF").withPresenter(presenter)
-            .withSubmittedAt(REPORT_DATE.atTime(10, 10, 10)).withFeeOnSubmission("10")
+            .withSubmittedAt(TEST_DATE.atTime(10, 10, 10)).withFeeOnSubmission("10")
             .withPaymentSessions(createPaymentSessions("PAY_SF"))
             .withStatus(SubmissionStatus.SUBMITTED).build();
         submissionSFF = builder.withId("SCOT_FAILED_FEE").withCompany(company).withFormDetails(FORM_SCOT_FEE)
             .withConfirmationReference("REF_SFF").withPresenter(presenter)
-            .withSubmittedAt(REPORT_DATE.atTime(11, 11, 11)).withFeeOnSubmission("10")
+            .withSubmittedAt(TEST_DATE.atTime(11, 11, 11)).withFeeOnSubmission("10")
             .withPaymentSessions(createPaymentSessions("PAY_SFF"))
             .withStatus(SubmissionStatus.REJECTED_BY_DOCUMENT_CONVERTER).build();
-        submissionNSF = builder.withId("NON_SCOT_FEE").withCompany(company).withFormDetails(FORM_NON_SCOT_FEE)
-            .withConfirmationReference("REF_NSF").withPresenter(presenter)
-            .withSubmittedAt(REPORT_DATE.atTime(12, 12, 12)).withFeeOnSubmission("10")
-            .withPaymentSessions(createPaymentSessions("PAY_NSF"))
-            .withStatus(SubmissionStatus.REJECTED).build();
         submissionNSFF = builder.withId("FAILED_FEE").withCompany(company).withFormDetails(FORM_NON_SCOT_FEE)
             .withConfirmationReference("REF_FF").withPresenter(presenter)
-            .withSubmittedAt(REPORT_DATE.atTime(13, 13, 13)).withFeeOnSubmission("10")
+            .withSubmittedAt(TEST_DATE.atTime(13, 13, 13)).withFeeOnSubmission("10")
             .withPaymentSessions(createPaymentSessions("PAY_FF"))
             .withStatus(SubmissionStatus.REJECTED_BY_VIRUS_SCAN).build();
+    }
+
+    private PaymentReportServiceImpl createTestServiceSpy(final int reportPeriodDaysBeforeToday) {
+        final Clock clock =
+            Clock.fixed(TEST_DATE.plusDays(reportPeriodDaysBeforeToday).atTime(NOW_TIME).toInstant(ZoneOffset.UTC), ZoneOffset.UTC);
+
+        PaymentReportServiceImpl spyService = spy(new PaymentReportServiceImpl(emailService,
+            new ReportQueryServiceImpl(submissionRepository, reportMapper), outputStreamWriterFactory, s3ClientService,
+            clock, BUCKET_NAME));
+        ReflectionTestUtils.setField(spyService, "scotlandReportPattern", REPORT_SCOT);
+        ReflectionTestUtils.setField(spyService, "scotlandForms", SCOT_FORM_LIST);
+        ReflectionTestUtils.setField(spyService, "failedTransactionsFinanceReportPattern", REPORT_FAILED);
+        ReflectionTestUtils.setField(spyService, "reportPeriodDaysBeforeToday", reportPeriodDaysBeforeToday);
+
+        return spyService;
     }
 
     @Test
     void sendScotlandPaymentReport() throws IOException {
         expectFindPaidSubmissions(PaymentReportServiceImpl.SUCCESSFUL_STATUSES,
-            Collections.singletonList(submissionSF));
+            Collections.singletonList(submissionSF), TEST_DATE);
         when(outputStreamWriterFactory.createFor(any(BufferedOutputStream.class))).thenCallRealMethod();
 
         final String reportName = "EFS_ScottishPaymentTransactions_2020-08-31.csv";
-
         final String fileLink = "link.to.uploaded.file";
 
         when(s3ClientService.getResourceId(anyString())).thenAnswer(invocation -> ENV_NAME + "/" + invocation.getArgument(0));
         when(s3ClientService.generateFileLink(ENV_NAME + "/" + reportName, BUCKET_NAME)).thenReturn(fileLink);
 
-        spyService.sendScotlandPaymentReport();
+        testService.sendScotlandPaymentReport();
 
         verify(emailService).sendPaymentReportEmail(emailCaptor.capture());
 
@@ -145,13 +145,19 @@ class PaymentReportServiceImplTest {
     }
 
     @Test
+    void sendOlderScotlandPaymentReport() throws IOException {
+        testService = createTestServiceSpy(5); // NOW is 5 days *after* TEST_DATE
+        sendScotlandPaymentReport();
+    }
+
+    @Test
     void sendScotlandPaymentReportWhenWriterFails() throws IOException {
-        expectFindPaidSubmissions(PaymentReportServiceImpl.SUCCESSFUL_STATUSES, Collections.emptyList());
+        expectFindPaidSubmissions(PaymentReportServiceImpl.SUCCESSFUL_STATUSES, Collections.emptyList(), TEST_DATE);
         when(outputStreamWriterFactory.createFor(any(BufferedOutputStream.class))).thenReturn(outputStreamWriter);
         doThrow(new IOException("expected failure")).when(outputStreamWriter)
             .write(any(char[].class), anyInt(), anyInt());
 
-        final IOException exception = assertThrows(IOException.class, () -> spyService.sendScotlandPaymentReport());
+        final IOException exception = assertThrows(IOException.class, () -> testService.sendScotlandPaymentReport());
 
         assertThat(exception.getMessage(), is("expected failure"));
     }
@@ -162,11 +168,11 @@ class PaymentReportServiceImplTest {
         final String failedFileLink = "link.to.uploaded.failed.file";
 
         expectFindPaidSubmissions(PaymentReportServiceImpl.FAILED_STATUSES,
-            Arrays.asList(submissionSFF, submissionNSFF));
+            Arrays.asList(submissionSFF, submissionNSFF), TEST_DATE);
         expectReportUpload(failedFileLink, failedReportName);
         when(outputStreamWriterFactory.createFor(any(BufferedOutputStream.class))).thenCallRealMethod();
 
-        spyService.sendFinancePaymentReports();
+        testService.sendFinancePaymentReports();
 
         verify(emailService).sendPaymentReportEmail(emailCaptor.capture());
 
@@ -181,11 +187,11 @@ class PaymentReportServiceImplTest {
         final String failedFileLink = "link.to.uploaded.failed.file";
 
         expectFindPaidSubmissions(PaymentReportServiceImpl.FAILED_STATUSES,
-            Collections.emptyList());
+            Collections.emptyList(), TEST_DATE);
         expectReportUpload(failedFileLink, failedReportName);
         when(outputStreamWriterFactory.createFor(any(BufferedOutputStream.class))).thenCallRealMethod();
 
-        spyService.sendFinancePaymentReports();
+        testService.sendFinancePaymentReports();
 
         verify(emailService).sendPaymentReportEmail(emailCaptor.capture());
 
@@ -199,8 +205,10 @@ class PaymentReportServiceImplTest {
         when(s3ClientService.generateFileLink(ENV_NAME + "/" + failedReportName, BUCKET_NAME)).thenReturn(failedFileLink);
     }
 
-    private void expectFindPaidSubmissions(ImmutableSet<SubmissionStatus> statuses, List<Submission> mappedList) {
-        when(submissionRepository.findPaidSubmissions(statuses, REPORT_DATE, REPORT_DATE.plusDays(1)))
+    private void expectFindPaidSubmissions(ImmutableSet<SubmissionStatus> statuses, List<Submission> mappedList,
+        final LocalDate reportStartDate) {
+        // report period should be 1 day long
+        when(submissionRepository.findPaidSubmissions(statuses, reportStartDate, reportStartDate.plusDays(1)))
             .thenReturn(mappedList);
         mappedList.forEach(s -> when(reportMapper.map(s)).thenReturn(buildTransaction(s)));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
@@ -1,10 +1,10 @@
 package uk.gov.companieshouse.efs.api.submissions.repository;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ import uk.gov.companieshouse.efs.api.submissions.model.Submission;
 import uk.gov.companieshouse.efs.api.util.CurrentTimestampGenerator;
 
 @ExtendWith(MockitoExtension.class)
-public class SubmissionRepositoryImplTest {
+class SubmissionRepositoryImplTest {
 
     private static final String ID = "_id";
     private static final String FORM_BARCODE = "form.barcode";
@@ -35,6 +35,9 @@ public class SubmissionRepositoryImplTest {
     private static final String SUBMITTED_AT = "submitted_at";
     private static final String FEE_ON_SUBMISSION = "fee_on_submission";
     private static final String LAST_MODIFIED_AT = "last_modified_at";
+    private static final LocalDate START_DATE = LocalDate.of(2020, 8, 31);
+    private static final LocalDate END_DATE = LocalDate.of(2020, 9, 1);
+
 
     private SubmissionRepositoryImpl repository;
 
@@ -53,13 +56,13 @@ public class SubmissionRepositoryImplTest {
     private LocalDateTime localDateTime;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         this.localDateTime = LocalDateTime.now();
         repository = new SubmissionRepositoryImpl(template, timestampGenerator);
     }
 
     @Test
-    public void testCreate() {
+    void testCreate() {
         // given
         Submission submission = Mockito.mock(Submission.class);
         // when
@@ -69,7 +72,7 @@ public class SubmissionRepositoryImplTest {
     }
 
     @Test
-    public void testUpdateSubmission() {
+    void testUpdateSubmission() {
         // given
         Submission submission = Mockito.mock(Submission.class);
         // when
@@ -79,7 +82,7 @@ public class SubmissionRepositoryImplTest {
     }
 
     @Test
-    public void testUpdateSubmissionStatus() {
+    void testUpdateSubmissionStatus() {
         // given
         SubmissionStatus status = SubmissionStatus.SUBMITTED;
         when(timestampGenerator.generateTimestamp()).thenReturn(this.localDateTime);
@@ -91,7 +94,7 @@ public class SubmissionRepositoryImplTest {
     }
 
     @Test
-    public void testFindByStatus() {
+    void testFindByStatus() {
         // given
         SubmissionStatus status = SubmissionStatus.SUBMITTED;
         int maxQueueCount = 50;
@@ -115,7 +118,7 @@ public class SubmissionRepositoryImplTest {
     }
 
     @Test
-    public void testReadByBarcode() {
+    void testReadByBarcode() {
         // given
         when(submission.getId()).thenReturn("1234");
         when(template.findOne(any(), eq(Submission.class), any())).thenReturn(submission);
@@ -143,7 +146,7 @@ public class SubmissionRepositoryImplTest {
     }
 
     @Test
-    public void testUpdateSubmissionStatusByBarcode() {
+    void testUpdateSubmissionStatusByBarcode() {
         // given
         when(timestampGenerator.generateTimestamp()).thenReturn(localDateTime);
         FesSubmissionStatus status = FesSubmissionStatus.ACCEPTED;
@@ -159,9 +162,6 @@ public class SubmissionRepositoryImplTest {
 
     @Test
     void testUpdateBarcode() {
-        //given
-        LocalDateTime now = LocalDateTime.now();
-
         //when
         repository.updateBarcode(SUBMISSION_ID, BARCODE);
 
@@ -187,16 +187,13 @@ public class SubmissionRepositoryImplTest {
 
     @Test
     void findSuccessfulPaidSubmissions() {
-        //given
-        LocalDate today = LocalDate.now();
-
         //when
-        repository.findPaidSubmissions(SubmissionRepositoryImpl.SUCCESSFUL_STATUSES, today.minusDays(1));
+        repository.findPaidSubmissions(SubmissionRepositoryImpl.SUCCESSFUL_STATUSES, START_DATE, END_DATE);
 
         //then
         verify(template).find(Query.query(
             Criteria.where(STATUS).in(SubmissionRepositoryImpl.SUCCESSFUL_STATUSES).and(SUBMITTED_AT)
-                .gt(today.minusDays(2)).lt(today).and(FEE_ON_SUBMISSION).exists(true)), Submission.class,
+                .gte(START_DATE).lt(END_DATE).and(FEE_ON_SUBMISSION).exists(true)), Submission.class,
             SUBMISSIONS_COLLECTION);
     }
 }


### PR DESCRIPTION
- fix error in report start date calculation
- ensure the report period is always 1 day long and
$REPORT_PERIOD_DAYS_BEFORE_TODAY days ago

Resolves:
BI-5535