### PR TITLE
Add msg text ids for all existing Share Capital forms

### DIFF
--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -2682,103 +2682,118 @@
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH04",
   "formName" : "SH04 - Notify a sale or transfer of treasury shares",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH05",
   "formName" : "SH05 - Notify a cancellation of treasury shares",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH06",
   "formName" : "SH06 - Notify a cancellation of shares",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH07",
   "formName" : "SH07 - Notify a cancellation of shares held by or for a public company",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH08",
   "formName" : "SH08 - Notify a name or other designation of class of shares",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH09",
   "formName" : "SH09 - Allotting a new class of shares by an unlimited company",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH10",
   "formName" : "SH10 - Give notice of particulars of variation of rights attached to shares",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH11",
   "formName" : "SH11 - Give notice of a new class of members",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH12",
   "formName" : "SH12 - Give notice of particulars of variation of class rights",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH13",
   "formName" : "SH13 - Give notice of name or other designation of class of members",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH14",
   "formName" : "SH14 - Notify a redenomination of shares",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH15",
   "formName" : "SH15 - Notify a reduction of capital following redenomination",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH16",
   "formName" : "SH16 - Give notice of application to court to cancel special resolution",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 }, {
   "_id" : "SH17",
   "formName" : "SH17 - Give notice by the company of application to cancel special resolution",
   "formCategory" : "SH",
   "fee" : "",
   "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
+  "isFesEnabled" : true,
+  "messageTextIdList": [1,4]
 } ]


### PR DESCRIPTION
Add the msg text ids required for web to dynamically display text on Document Upload screen.

BI-6639

Corresponding web PR: https://github.com/companieshouse/efs-submission-web/pull/39