### PR TITLE
Add partnership company prefixes for Internal email

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/email/FormCategoryToEmailAddressService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/FormCategoryToEmailAddressService.java
@@ -7,6 +7,7 @@ import static uk.gov.companieshouse.efs.api.categorytemplates.model.CategoryType
 import static uk.gov.companieshouse.efs.api.categorytemplates.model.CategoryTypeConstants.SHARE_CAPITAL;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
@@ -33,6 +34,11 @@ public class FormCategoryToEmailAddressService {
     private String internalScottishPartnershipsEmailAddress;
     private String internalInsolvencyEmailAddress;
     private String internalSharedCapitalEmailAddress;
+    @Value("${scotland.company.prefixes}")
+    private List<String> scotlandCompanyPrefixes;
+    @Value("${northernIreland.company.prefixes}")
+    private List<String> northernIrelandCompanyPrefixes;
+
     private Map<String, String> formTypeEmailMap;
     private static final Logger LOGGER = LoggerFactory.getLogger("efs-submission-api");
 
@@ -97,10 +103,10 @@ public class FormCategoryToEmailAddressService {
 
     public String getEmailAddressForRegPowersFormCategory(String formType, String companyNumber) {
 
-        if (companyNumber.startsWith("SC") || companyNumber.startsWith("SL")) {
+        if (scotlandCompanyPrefixes.stream().anyMatch(companyNumber::startsWith)) {
             return internalScotEmailAddress;
 
-        } else if (companyNumber.startsWith("NI")) {
+        } else if (northernIrelandCompanyPrefixes.stream().anyMatch(companyNumber::startsWith)) {
             return internalNIEmailAddress;
 
         } else {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,3 +67,6 @@ scotland.payment.form.types=${SCOTLAND_PAYMENT_FORM_TYPES}
 payment.report.bucket.name=${PAYMENT_REPORT_BUCKET_NAME}
 report.period.days.before.today=${REPORT_PERIOD_DAYS_BEFORE_TODAY}
 env.name=${ENV_NAME}
+
+scotland.company.prefixes=${SCOTLAND_COMPANY_PREFIXES}
+northernIreland.company.prefixes=${NORTHERN_IRELAND_COMPANY_PREFIXES}


### PR DESCRIPTION
- adds a configurable property for Scotland and Northern Ireland company prefixes
- checks through those lists
- add a few more unit tests for these prefixes

Corresponding config PR: https://github.com/companieshouse/chs-configs/pull/1430

BI-6744

I went thru' every prefix listed and a few made up ones, email addresses as expected:

<img width="519" alt="Screenshot 2021-02-04 at 14 43 22" src="https://user-images.githubusercontent.com/2736331/106908760-8177cf00-66f7-11eb-91b7-4a7337be4e0e.png">
