### PR TITLE
Add payment to confirmation email data

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/ExternalConfirmationEmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/ExternalConfirmationEmailMapper.java
@@ -60,6 +60,7 @@ public class ExternalConfirmationEmailMapper {
                 .withFormType(model.getSubmission().getFormDetails().getFormType())
                 .withTopLevelCategory(getTopLevelCategoryForFormType(model))
                 .withEmailFileDetailsList(createEmailFileDetailsList(model.getSubmission().getFormDetails().getFileDetailsList()))
+                .withFeeOnSubmission(model.getSubmission().getFeeOnSubmission())
                 .build();
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/ExternalConfirmationEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/ExternalConfirmationEmailData.java
@@ -23,10 +23,13 @@ public class ExternalConfirmationEmailData {
     private CategoryTypeConstants topLevelCategory;
     @JsonProperty("email_file_details_list")
     private List<EmailFileDetails> emailFileDetailsList;
+    @JsonProperty("fee_on_submission")
+    private String feeOnSubmission;
 
     public ExternalConfirmationEmailData(String to, String subject, String confirmationReference,
                                          Presenter presenter, Company company, String formType,
-                                         CategoryTypeConstants topLevelCategory, List<EmailFileDetails> emailFileDetailsList) {
+                                         CategoryTypeConstants topLevelCategory, List<EmailFileDetails> emailFileDetailsList,
+                                         String feeOnSubmission) {
         this.to = to;
         this.subject = subject;
         this.confirmationReference = confirmationReference;
@@ -35,6 +38,7 @@ public class ExternalConfirmationEmailData {
         this.formType = formType;
         this.topLevelCategory = topLevelCategory;
         this.emailFileDetailsList = emailFileDetailsList;
+        this.feeOnSubmission = feeOnSubmission;
     }
 
     public String getTo() {
@@ -101,6 +105,14 @@ public class ExternalConfirmationEmailData {
         this.emailFileDetailsList = emailFileDetailsList;
     }
 
+    public String getFeeOnSubmission() {
+        return feeOnSubmission;
+    }
+
+    public void setFeeOnSubmission(final String feeOnSubmission) {
+        this.feeOnSubmission = feeOnSubmission;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -117,14 +129,15 @@ public class ExternalConfirmationEmailData {
                    .equals(getCompany(), that.getCompany()) && Objects
                    .equals(getFormType(), that.getFormType()) && Objects
                    .equals(getTopLevelCategory(), that.getTopLevelCategory())  && Objects
-                   .equals(getEmailFileDetailsList(), that.getEmailFileDetailsList());
+                   .equals(getEmailFileDetailsList(), that.getEmailFileDetailsList()) && Objects
+                   .equals(getFeeOnSubmission(), that.getFeeOnSubmission());
     }
 
     @Override
     public int hashCode() {
         return Objects
             .hash(getTo(), getSubject(), getConfirmationReference(), getPresenter(), getCompany(),
-                getFormType(), getTopLevelCategory(), getEmailFileDetailsList());
+                getFormType(), getTopLevelCategory(), getEmailFileDetailsList(), getFeeOnSubmission());
     }
 
     public static ExternalConfirmationEmailData.Builder builder() {
@@ -141,6 +154,7 @@ public class ExternalConfirmationEmailData {
         private String formType;
         private CategoryTypeConstants topLevelCategory;
         private List<EmailFileDetails> emailFileDetailsList;
+        private String feeOnSubmission;
 
         public ExternalConfirmationEmailData.Builder withTo(String to) {
             this.to = to;
@@ -183,9 +197,14 @@ public class ExternalConfirmationEmailData {
             return this;
         }
 
+        public ExternalConfirmationEmailData.Builder withFeeOnSubmission(String feeOnSubmission) {
+            this.feeOnSubmission = feeOnSubmission;
+            return this;
+        }
+
         public ExternalConfirmationEmailData build() {
             return new ExternalConfirmationEmailData(to, subject, confirmationReference, presenter, company, formType,
-                    topLevelCategory, emailFileDetailsList);
+                    topLevelCategory, emailFileDetailsList, feeOnSubmission);
         }
 
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/ExternalConfirmationEmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/ExternalConfirmationEmailMapperTest.java
@@ -97,7 +97,7 @@ class ExternalConfirmationEmailMapperTest {
         when(submission.getPresenter()).thenReturn(presenter);
 
         when(submission.getConfirmationReference()).thenReturn("abcd3434343efsfg");
-
+        when(submission.getFeeOnSubmission()).thenReturn("17");
         when(formDetails.getFileDetailsList()).thenReturn(Collections.singletonList(fileDetails));
 
         when(externalConfirmationEmailModel.getSubmission()).thenReturn(submission);
@@ -132,6 +132,7 @@ class ExternalConfirmationEmailMapperTest {
                                 .withConfirmationReference("abcd3434343efsfg")
                                 .withEmailFileDetailsList(Collections.singletonList(new EmailFileDetails(fileDetails, null)))
                                 .withPresenter(presenter)
+                                .withFeeOnSubmission("17")
                                 .build())
                 .build();
     }


### PR DESCRIPTION
The `fee_on_submission` is already present in the submission data when appropriate.  
This just adds it to the ConfirmationEmailData.

email template PR: https://github.com/companieshouse/chs-notification-api/pull/257

BI-7082
