### PR TITLE
Upgrade spring-boot-dependencies to 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <web-security-java.version>1.3.1</web-security-java.version>
 
         <!-- Spring -->
-        <spring-boot-dependencies.version>2.2.0.RELEASE</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.4.4</spring-boot-dependencies.version>
         <spring-test.version>5.2.0.RELEASE</spring-test.version>
         <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
 


### PR DESCRIPTION
As part of a CHS Mongo upgrade, the drivers used also need to be updated. 

- These are set in the spring-boot dependencies and the latest is `2.4.4`
https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
- I have built and checked that data is stored in the db.

Jira: BI-7083