### PR TITLE
Fix Boot validation after version upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <kafka-models.version>1.0.12</kafka-models.version>
         <ojdbc6.version>11.2.0.3</ojdbc6.version>
-        <junit-jupiter.version>5.5.2</junit-jupiter.version>
-
+        <junit-jupiter.version>5.7.1</junit-jupiter.version>
+        <mockito-junit-jupiter.version>3.8.0</mockito-junit-jupiter.version>
         <commons-lang3.version>3.10</commons-lang3.version>
         <commons-io.version>2.6</commons-io.version>
         <equalsverifier.version>3.1.6</equalsverifier.version>
@@ -96,6 +96,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -205,6 +209,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito-junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- add spring-boot-starter-validation dependency removed from spring-boot-starter
- bump junit 5 to version 5.7.1
- bump mockito version to 3.8.0
- add mockito-inline dependency for mocking final classes/methods

Resolves:
BI-7083