### PR TITLE
Fix payment PATCH for failed outcome called BEFORE completion

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
@@ -414,16 +414,10 @@ public final class PaymentTemplate {
     public enum Status {
         PAID("paid"), PENDING("pending"), FAILED("failed");
 
-        private String value;
+        private final String value;
 
         Status(String value) {
             this.value = value;
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return String.valueOf(value);
         }
 
         /**
@@ -440,6 +434,12 @@ public final class PaymentTemplate {
                 }
             }
             return null;
+        }
+
+        @Override
+        @JsonValue
+        public String toString() {
+            return String.valueOf(value);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
@@ -184,7 +184,7 @@ public class SubmissionServiceImpl implements SubmissionService {
         switch (status) {
             case OPEN:
                 resultStatus = paymentClose.isFailed()
-                    ? SubmissionStatus.PAYMENT_FAILED
+                    ? SubmissionStatus.OPEN
                     : SubmissionStatus.PAYMENT_RECEIVED;
                 break;
             case PAYMENT_REQUIRED:
@@ -200,8 +200,8 @@ public class SubmissionServiceImpl implements SubmissionService {
         }
         submission.setStatus(resultStatus);
         submission.setLastModifiedAt(timestampGenerator.generateTimestamp());
-        LOGGER.debug(String.format(SUBMISSION_STATUS_MSG, resultStatus, submission.getId()));
         submissionRepository.updateSubmission(submission);
+        LOGGER.debug(String.format(SUBMISSION_STATUS_MSG, resultStatus, submission.getId()));
 
         return new SubmissionResponseApi(id);
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImplTest.java
@@ -930,7 +930,7 @@ class SubmissionServiceImplTest {
         assertEquals(SUBMISSION_ID, actual.getId());
         assertThat(submission.getPaymentSessions().get(0).getSessionStatus(),
             is(STATUS_FAILED));
-        verify(submission).setStatus(SubmissionStatus.PAYMENT_FAILED);
+        verify(submission).setStatus(SubmissionStatus.OPEN);
         verify(timestampGenerator).generateTimestamp();
         verify(submission).setLastModifiedAt(now);
         verifyNoMoreInteractions(submission, emailService);


### PR DESCRIPTION
- keep submission status OPEN; allow user to retry payment
- reorder methods in PaymentTemplate.Status to avoid duplicate code detection

Resolves:
BI-7733