### PR TITLE
Extend dynamic guidance to category / document selection screens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.70</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>2.0.68</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>

--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateController.java
@@ -72,7 +72,6 @@ public class CategoryTemplateController {
      */
     @GetMapping(value = "/category-template/{id}")
     public ResponseEntity<CategoryTemplateApi> getCategoryTemplate(@PathVariable String id, HttpServletRequest request) {
-
         try {
             return ResponseEntity.ok().body(categoryService.getCategoryTemplate(id));
         } catch (Exception ex) {
@@ -82,5 +81,11 @@ public class CategoryTemplateController {
             logger.error("Failed to get category template", ex, debug);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    @GetMapping(value = "/category-template/")
+    public ResponseEntity<CategoryTemplateApi> getRootCategory(HttpServletRequest request) {
+        final String id = "ROOT";
+        return getCategoryTemplate(id, request);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/mapper/CategoryTemplateMapper.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/mapper/CategoryTemplateMapper.java
@@ -20,11 +20,8 @@ public class CategoryTemplateMapper {
      */
     public CategoryTemplateListApi map(List<CategoryTemplate> categoryTemplates) {
         return categoryTemplates.stream()
-                .map(form -> new CategoryTemplateApi(
-                        form.getCategoryType(),
-                        form.getCategoryName(),
-                        form.getParent(),
-                        form.getCategoryHint())).collect(Collectors.toCollection(CategoryTemplateListApi::new));
+                .map(this::map)
+                .collect(Collectors.toCollection(CategoryTemplateListApi::new));
     }
 
     /**
@@ -38,6 +35,7 @@ public class CategoryTemplateMapper {
                 categoryTemplate.getCategoryType(),
                 categoryTemplate.getCategoryName(),
                 categoryTemplate.getParent(),
-                categoryTemplate.getCategoryHint());
+                categoryTemplate.getCategoryHint(),
+                categoryTemplate.getGuidanceTexts());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplate.java
@@ -2,7 +2,12 @@ package uk.gov.companieshouse.efs.api.categorytemplates.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.annotation.Id;
@@ -36,18 +41,26 @@ public class CategoryTemplate {
     @Field
     private String categoryHint;
 
+    @JsonProperty("guidance_text_list")
+    @Field
+    private List<Integer> guidanceTexts;
+
     /**
      * Constructor which sets the submission form category data.
      * @param categoryType the category type
      * @param categoryName the category name
      * @param parent used when the category has a parent category
      * @param categoryHint the category hint
+     * @param guidanceTexts a list of id's of guidance fragments to show on the category
+     *                               selection screen
      */
-    public CategoryTemplate(String categoryType, String categoryName, String parent, String categoryHint) {
+    public CategoryTemplate(String categoryType, String categoryName, String parent,
+                            String categoryHint, final List<Integer> guidanceTexts) {
         this.categoryType = categoryType;
         this.categoryName = categoryName;
         this.parent = parent;
         this.categoryHint = categoryHint;
+        this.guidanceTexts = guidanceTexts;
     }
 
     public String getCategoryType() {
@@ -66,6 +79,15 @@ public class CategoryTemplate {
         return categoryHint;
     }
 
+    public List<Integer> getGuidanceTexts() {
+        return Optional.ofNullable(guidanceTexts)
+                .orElse(Collections.emptyList());
+    }
+
+    public void setGuidanceTexts(List<Integer> guidanceTexts) {
+        this.guidanceTexts = guidanceTexts;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -78,12 +100,14 @@ public class CategoryTemplate {
         return Objects.equals(getCategoryType(), that.getCategoryType()) && Objects
             .equals(getCategoryName(), that.getCategoryName()) && Objects
                    .equals(getParent(), that.getParent()) && Objects
-                   .equals(getCategoryHint(), that.getCategoryHint());
+                   .equals(getCategoryHint(), that.getCategoryHint()) && Objects
+                   .equals(getGuidanceTexts(), that.getGuidanceTexts());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getCategoryType(), getCategoryName(), getParent(), getCategoryHint());
+        return Objects.hash(getCategoryType(), getCategoryName(), getParent(), getCategoryHint(),
+                getGuidanceTexts());
     }
 
     @Override
@@ -93,6 +117,7 @@ public class CategoryTemplate {
                 .append("categoryName", getCategoryName())
                 .append("parent", getParent())
                 .append("categoryHint", getCategoryHint())
+                .append("guidanceTexts", getGuidanceTexts())
                 .toString();
     }
 }

--- a/src/main/resources/category_templates.json
+++ b/src/main/resources/category_templates.json
@@ -1,4 +1,8 @@
 [ {
+  "_id" : "ROOT",
+  "categoryName" : "ROOT",
+  "parent" : ""
+}, {
   "_id" : "INS",
   "categoryName" : "Insolvency",
   "parent" : ""

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,8 @@ import javax.servlet.http.HttpServletRequest;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -110,5 +113,13 @@ class CategoryTemplateControllerTest {
 
         //then
         assertThat(actual.getStatusCodeValue(), is(500));
+    }
+
+    @Test
+    void testGetRootCategoryTest() {
+        controller.getRootCategory(request);
+
+        verify(service).getCategoryTemplate("ROOT");
+        verifyNoMoreInteractions(service);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/mapper/CategoryTemplateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/mapper/CategoryTemplateMapperTest.java
@@ -45,16 +45,19 @@ class CategoryTemplateMapperTest {
     }
 
     private CategoryTemplate getCategory() {
-        return new CategoryTemplate("MA", "New Incorporation", "", "");
+        return new CategoryTemplate("MA", "New Incorporation",
+                "", "", null);
     }
 
     private CategoryTemplateListApi expectedList() {
-        CategoryTemplateApi element = new CategoryTemplateApi("MA", "New Incorporation", "", "");
+        CategoryTemplateApi element = new CategoryTemplateApi("MA", "New Incorporation", "", "",
+                Collections.emptyList());
         return new CategoryTemplateListApi(Collections.singletonList(element));
     }
 
     private CategoryTemplateApi expectedSingle() {
-        CategoryTemplateApi element = new CategoryTemplateApi("MA", "New Incorporation", "", "");
+        CategoryTemplateApi element = new CategoryTemplateApi("MA", "New Incorporation", "", "",
+                Collections.emptyList());
         return new CategoryTemplateApi(element);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplateTest.java
@@ -21,7 +21,8 @@ class CategoryTemplateTest {
 
     @BeforeEach
     void setUp() {
-        testCategoryTemplate = new CategoryTemplate("CC01", "Category01", "", "");
+        testCategoryTemplate = new CategoryTemplate("CC01",
+                "Category01", "", "", null);
         JacksonTester.initFields(this, new ObjectMapper());
     }
 
@@ -44,7 +45,7 @@ class CategoryTemplateTest {
     void toStringTest() {
         assertThat(testCategoryTemplate.toString(), Matchers.is(
                 //@formatter:off
-                "CategoryTemplate[categoryType=CC01,categoryName=Category01,parent=,categoryHint=]"
+                "CategoryTemplate[categoryType=CC01,categoryName=Category01,parent=,categoryHint=,guidanceTexts=[]]"
                 //@formatter:on
         ));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
@@ -79,8 +79,8 @@ class CategoryTemplateServiceImplTest {
 
         //given
         String categoryId = "CC01";
-        CategoryTemplate category = new CategoryTemplate(categoryId, "CatCat", null, null);
-        CategoryTemplateApi mappedCategory = new CategoryTemplateApi(categoryId, "CatCat", null, null);
+        CategoryTemplate category = new CategoryTemplate(categoryId, "CatCat", null, null, null);
+        CategoryTemplateApi mappedCategory = new CategoryTemplateApi(categoryId, "CatCat", null, null, null);
 
         when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
         when(mapper.map(category)).thenReturn(mappedCategory);
@@ -112,7 +112,7 @@ class CategoryTemplateServiceImplTest {
 
         //given
         String categoryId = "CC01";
-        CategoryTemplate mappedCategory = new CategoryTemplate(categoryId, "CatCat", null, null);
+        CategoryTemplate mappedCategory = new CategoryTemplate(categoryId, "CatCat", null, null, null);
 
         List<CategoryTemplate> listCategory = new ArrayList<>();
         listCategory.add(mappedCategory);


### PR DESCRIPTION
This PR supports this [web PR](https://github.com/companieshouse/efs-submission-web/pull/76).

Adds support for a new field in the category template collection to specify guidance text fragment IDs so that they can be displayed on the category and document selection screens.

[BI-7097](https://companieshouse.atlassian.net/browse/BI-7097)