### PR TITLE
Refactor form_templates db collection to allow duplications across form categories

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/InternalSubmissionEmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/InternalSubmissionEmailMapper.java
@@ -1,10 +1,10 @@
 package uk.gov.companieshouse.efs.api.email.mapper;
 
+import static uk.gov.companieshouse.efs.api.categorytemplates.model.CategoryTypeConstants.REGISTRAR_POWERS;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.springframework.stereotype.Component;
-
 import uk.gov.companieshouse.efs.api.categorytemplates.model.CategoryTypeConstants;
 import uk.gov.companieshouse.efs.api.categorytemplates.service.CategoryTemplateService;
 import uk.gov.companieshouse.efs.api.email.FormCategoryToEmailAddressService;
@@ -15,8 +15,6 @@ import uk.gov.companieshouse.efs.api.email.model.InternalSubmissionEmailModel;
 import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.efs.api.util.IdentifierGeneratable;
 import uk.gov.companieshouse.efs.api.util.TimestampGenerator;
-
-import static uk.gov.companieshouse.efs.api.categorytemplates.model.CategoryTypeConstants.REGISTRAR_POWERS;
 
 @Component
 public class InternalSubmissionEmailMapper {
@@ -45,9 +43,8 @@ public class InternalSubmissionEmailMapper {
 
         String emailAddress;
         String formType = model.getSubmission().getFormDetails().getFormType();
-        CategoryTypeConstants categoryType =
-                categoryTemplateService.getTopLevelCategory(
-                        formTemplateService.getFormTemplate(formType).getFormCategory());
+        CategoryTypeConstants categoryType = categoryTemplateService.getTopLevelCategory(
+            formTemplateService.getFormTemplate(formType).getFormCategory());
 
         if (categoryType.getValue().equals(REGISTRAR_POWERS.getValue())) {
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngine.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngine.java
@@ -5,10 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-
 import uk.gov.companieshouse.api.model.efs.submissions.FileConversionStatus;
 import uk.gov.companieshouse.efs.api.events.service.model.Decision;
 import uk.gov.companieshouse.efs.api.events.service.model.DecisionResult;
@@ -100,7 +98,9 @@ public class DecisionEngine {
     }
 
     private Decision decide(Decision decision, String formType) {
-        Optional<FormTemplate> formTemplate = repository.findById(formType);
+        final List<FormTemplate> formTemplateList = repository.findByIdFormType(formType);
+        final Optional<FormTemplate> formTemplate = formTemplateList.stream().findFirst();
+
         if (decision.getExpectedDecisions() != decision.getNumberOfDecisions()) {
             decision.setDecisionResult(DecisionResult.NO_DECISION);
         } else if (decision.containsInfectedFile()) {

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateController.java
@@ -70,15 +70,15 @@ public class FormTemplateController {
      * @return responseEntity
      */
     @GetMapping(value = "/form-template")
-    public ResponseEntity<FormTemplateApi> getFormTemplate(@RequestParam("type") String id,
-        HttpServletRequest request) {
+    public ResponseEntity<FormTemplateApi> getFormTemplate(@RequestParam("type") String formType, HttpServletRequest request) {
 
         try {
-            return ResponseEntity.ok().body(formService.getFormTemplate(id));
-        } catch (Exception ex) {
+            return ResponseEntity.ok().body(formService.getFormTemplate(formType));
+        }
+        catch (Exception ex) {
             Map<String, Object> debug = new HashMap<>();
 
-            debug.put("id", id);
+            debug.put("formType", formType);
             logger.error("Failed to get form template", ex, debug);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplate.java
@@ -20,7 +20,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class FormTemplate implements Serializable {
 
     @EmbeddedId
-    private FormTypeKey id;
+    private FormTypeId id;
  
     @JsonProperty("form_name")
     @Field
@@ -52,7 +52,7 @@ public class FormTemplate implements Serializable {
      * @param isFesEnabled is fes enabled
      * @param messageTextIdList list of message textids
      */
-    public FormTemplate(final FormTypeKey id, final String formName, final String fee, final boolean isAuthenticationRequired,
+    public FormTemplate(final FormTypeId id, final String formName, final String fee, final boolean isAuthenticationRequired,
         final boolean isFesEnabled, final List<Integer> messageTextIdList) {
         this.id = id;
         this.formName = formName;
@@ -62,16 +62,16 @@ public class FormTemplate implements Serializable {
         this.messageTextIdList = messageTextIdList;
     }
 
-    public FormTypeKey getId() {
+    public FormTypeId getId() {
         return id;
     }
 
     public String getFormType() {
-        return Optional.ofNullable(id).map(FormTypeKey::getFormType).orElse(null);
+        return Optional.ofNullable(id).map(FormTypeId::getFormType).orElse(null);
     }
 
     public String getFormCategory() {
-        return Optional.ofNullable(id).map(FormTypeKey::getFormCategory).orElse(null);
+        return Optional.ofNullable(id).map(FormTypeId::getFormCategory).orElse(null);
     }
 
     public String getFormName() {
@@ -139,7 +139,7 @@ public class FormTemplate implements Serializable {
      * defines both equals() and hashCode() methods, and implements the Serializable interface.
      */
     @Embeddable
-    public static class FormTypeKey implements Serializable {
+    public static class FormTypeId implements Serializable {
         @JsonProperty("form_type")
         @Field
         private String formType;
@@ -148,11 +148,11 @@ public class FormTemplate implements Serializable {
         @Field
         private String formCategory;
 
-        public FormTypeKey() {
+        public FormTypeId() {
             // required by Spring Data
         }
 
-        public FormTypeKey(final String formType, final String formCategory) {
+        public FormTypeId(final String formType, final String formCategory) {
             this.formType = formType;
             this.formCategory = formCategory;
         }
@@ -165,7 +165,7 @@ public class FormTemplate implements Serializable {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            final FormTypeKey that = (FormTypeKey) o;
+            final FormTypeId that = (FormTypeId) o;
             return Objects.equals(formType, that.formType) && Objects.equals(formCategory, that.formCategory);
         }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/repository/FormTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/repository/FormTemplateRepository.java
@@ -7,7 +7,7 @@ import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 /**
  * Store and retrieve form template information.
  */
-public interface FormTemplateRepository extends MongoRepository<FormTemplate, FormTemplate.FormTypeKey> {
+public interface FormTemplateRepository extends MongoRepository<FormTemplate, FormTemplate.FormTypeId> {
 
     /**
      * Finds all form template details by form type.

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/repository/FormTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/repository/FormTemplateRepository.java
@@ -7,14 +7,21 @@ import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 /**
  * Store and retrieve form template information.
  */
-public interface FormTemplateRepository extends MongoRepository<FormTemplate, String> {
+public interface FormTemplateRepository extends MongoRepository<FormTemplate, FormTemplate.FormTypeKey> {
+
+    /**
+     * Finds all form template details by form type.
+     *
+     * @return List&lt;FormTemplate&gt;
+     */
+    List<FormTemplate> findByIdFormType(String form);
 
     /**
      * Finds all form template details by category.
      *
      * @return List&lt;FormTemplate&gt;
      */
-    List<FormTemplate> findByFormCategory(String category);
+    List<FormTemplate> findByIdFormCategory(String category);
 
 }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateService.java
@@ -16,7 +16,7 @@ public interface FormTemplateService {
      *
      * @return a submission form template
      */
-    default FormTemplateApi getFormTemplateById(FormTemplate.FormTypeKey id) {
+    default FormTemplateApi getFormTemplateById(FormTemplate.FormTypeId id) {
         throw new UnsupportedOperationException("not implemented");
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateService.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.efs.api.formtemplates.service;
 
 import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
 import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateListApi;
+import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 
 /**
  * Stores and retrieves the form template information.
@@ -9,22 +10,34 @@ import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateListApi;
 public interface FormTemplateService {
 
     /**
+     * Retrieve a submission form type by composite id.
+     *
+     * @param id form type id
+     *
+     * @return a submission form template
+     */
+    default FormTemplateApi getFormTemplateById(FormTemplate.FormTypeKey id) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
      * Retrieve all submission form types.
      *
-     * @return list of submission form templates
+     * @return list of submission form templates list
      */
     default FormTemplateListApi getFormTemplates() {
         throw new UnsupportedOperationException("not implemented");
     }
 
     /**
-     * Retrieve a submission form type.
+     * Retrieve a submission form type by form type only.
+     * Assumes multiple results are equivalent, and returns the first one.
      *
-     * @param id form type id
+     * @param formType form type
      *
      * @return a submission form template
      */
-    default FormTemplateApi getFormTemplate(String id) {
+    default FormTemplateApi getFormTemplate(String formType) {
         throw new UnsupportedOperationException("not implemented");
     }
 
@@ -32,7 +45,7 @@ public interface FormTemplateService {
      * Retrieve a list of submission forms belonging to a form category.
      *
      * @param id form category id
-     * @return a submission form template
+     * @return a submission form template list
      */
     default FormTemplateListApi getFormTemplatesByCategory(String id) {
         throw new UnsupportedOperationException("not implemented");

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImpl.java
@@ -34,7 +34,7 @@ public class FormTemplateServiceImpl implements FormTemplateService {
     }
 
     @Override
-    public FormTemplateApi getFormTemplateById(final FormTemplate.FormTypeKey id) {
+    public FormTemplateApi getFormTemplateById(final FormTemplate.FormTypeId id) {
         return repository.findById(id).map(mapper::map).orElse(null);
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.formtemplates.service;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,8 @@ import uk.gov.companieshouse.efs.api.formtemplates.repository.FormTemplateReposi
 @Import(Config.class)
 public class FormTemplateServiceImpl implements FormTemplateService {
 
-    private FormTemplateRepository repository;
-    private FormTemplateMapper mapper;
+    private final FormTemplateRepository repository;
+    private final FormTemplateMapper mapper;
 
     /**
      * FormTemplateService constructor.
@@ -33,20 +34,27 @@ public class FormTemplateServiceImpl implements FormTemplateService {
     }
 
     @Override
+    public FormTemplateApi getFormTemplateById(final FormTemplate.FormTypeKey id) {
+        return repository.findById(id).map(mapper::map).orElse(null);
+    }
+
+    @Override
     public FormTemplateListApi getFormTemplates() {
         List<FormTemplate> formTemplates = repository.findAll();
         return mapper.map(formTemplates);
     }
 
     @Override
-    public FormTemplateApi getFormTemplate(String id) {
-        FormTemplate formTemplate = repository.findById(id).orElse(null);
-        return formTemplate == null ? null : mapper.map(formTemplate);
+    public FormTemplateApi getFormTemplate(String formType) {
+        List<FormTemplate> formTemplates = repository.findByIdFormType(formType);
+        return Optional.of(formTemplates).flatMap(list -> list.stream().findFirst())
+            .map(mapper::map)
+            .orElse(null);
     }
 
     @Override
     public FormTemplateListApi getFormTemplatesByCategory(final String id) {
-        final List<FormTemplate> byCategory = repository.findByFormCategory(id);
+        final List<FormTemplate> byCategory = repository.findByIdFormCategory(id);
         return mapper.map(byCategory);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
@@ -97,8 +97,10 @@ public class PaymentController {
         } else {
             String formType = submission.getSubmissionForm().getFormType();
 
-            logger.debug(MessageFormat.format("Fetching form type with id: {0}", formType));
+            logger.debug(MessageFormat.format("Fetching form type with formType: {0}", formType));
+            
             FormTemplateApi formTemplate = formTemplateService.getFormTemplate(formType);
+            
             if (formTemplate != null) {
                 final String chargeTemplateId = formTemplate.getPaymentCharge();
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/FesAttachmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/FesAttachmentValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.efs.api.submissions.validator;
 
+import java.util.List;
 import java.util.Optional;
 import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 import uk.gov.companieshouse.efs.api.formtemplates.repository.FormTemplateRepository;
@@ -17,7 +18,8 @@ public class FesAttachmentValidator extends ValidatorImpl<Submission> implements
     public void validate(final Submission input) throws SubmissionValidationException {
 
         if (formRepository != null) {
-            final Optional<FormTemplate> template = formRepository.findById(input.getFormDetails().getFormType());
+            final List<FormTemplate> formTemplateList = formRepository.findByIdFormType(input.getFormDetails().getFormType());
+            final Optional<FormTemplate> template = formTemplateList.stream().findFirst();
             final boolean hasAttachments = input.getFormDetails().getFileDetailsList().size() > 1;
 
             // don't throw if !template.isPresent()

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/FormTemplateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/FormTemplateValidator.java
@@ -13,7 +13,7 @@ public class FormTemplateValidator extends ValidatorImpl<Submission> implements 
 
     @Override
     public void validate(final Submission input) throws SubmissionValidationException {
-        if (repository != null && !repository.findById(input.getFormDetails().getFormType()).isPresent()) {
+        if (repository != null && repository.findByIdFormType(input.getFormDetails().getFormType()).isEmpty()) {
             throw new SubmissionValidationException(String
                 .format("Form type [%s] unknown in submission [%s]", input.getFormDetails().getFormType(),
                     input.getId()));

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/PaymentSessionsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/PaymentSessionsValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.submissions.validator;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.util.CollectionUtils;
@@ -26,7 +27,8 @@ public class PaymentSessionsValidator extends ValidatorImpl<Submission> implemen
         final boolean hasPaymentSessions = !CollectionUtils.isEmpty(input.getPaymentSessions());
 
         if (formRepository != null && paymentRepository != null) {
-            final Optional<FormTemplate> formTemplate = formRepository.findById(input.getFormDetails().getFormType());
+            final List<FormTemplate> formTemplateList = formRepository.findByIdFormType(input.getFormDetails().getFormType());
+            final Optional<FormTemplate> formTemplate = formTemplateList.stream().findFirst();
             final String formType = formTemplate.map(FormTemplate::getFormType).orElse(null);
             final String formFee = formTemplate.map(FormTemplate::getFee).orElse(null);
 

--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -1,2911 +1,4728 @@
-[ {
-  "_id" : "SLPCS01",
-  "formName" : "SLP CS01 - Confirmation statement for a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "SLPCS01",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC01",
-  "formName" : "SLP PSC01 - Give notice of individual person with significant control of a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC02",
-  "formName" : "SLP PSC02 - Give notice of relevant legal entity with significant control of a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC03",
-  "formName" : "SLP PSC03 - Give notice of other registrable person with significant control of a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC04",
-  "formName" : "SLP PSC04 - Give notice to change details of a person with significant control of a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC05",
-  "formName" : "SLP PSC05 - Give details of relevant legal entity with significant control of a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC06",
-  "formName" : "SLP PSC06 - Give notice changing details of other person with significant control of a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC07",
-  "formName" : "SLP PSC07 - Give notice of ceasing to be a PSC, RLE or ORP of a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC08",
-  "formName" : "SLP PSC08 - Give notice of a person of PSC statements for a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SLPPSC09",
-  "formName" : "SLP PSC09 - Give notice of update to PSC statements for a Scottish limited partnership",
-  "formCategory" : "SLP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPCS01",
-  "formName" : "SQP CS01 - Confirmation statement for a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "SQPCS01",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQP2",
-  "formName" : "SQP2 - Give notice of a change of details for a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQP3",
-  "formName" : "SQP3 - Give notice of ceasing to be a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC01",
-  "formName" : "SQP PSC01 - Give notice of individual person with significant control of a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC02",
-  "formName" : "SQP PSC02 - Give notice of relevant legal entity with significant control of a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC03",
-  "formName" : "SQP PSC03 - Give notice of other registrable person with significant control of a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC04",
-  "formName" : "SQP PSC04 - Give notice to change details of a person with significant control of a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC05",
-  "formName" : "SQP PSC05 - Give details of relevant legal entity with significant control of a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC06",
-  "formName" : "SQP PSC06 - Give notice changing details of other person with significant control of a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC07",
-  "formName" : "SQP PSC07 - Give notice of ceasing to be a PSC, RLE or ORP of a Scottish Qualifying Partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC08",
-  "formName" : "SQP PSC08 - Give notice of PSC statements for a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "SQPPSC09",
-  "formName" : "SQP PSC09 - Give notice of update to PSC statements for a Scottish qualifying partnership",
-  "formCategory" : "SQP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "RP02A",
-  "formName" : "RP02A - Apply for rectification by the registrar of companies",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1,2]
-}, {
-  "_id" : "RP02B",
-  "formName" : "RP02B - Apply for rectification for a change of registered address",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "RP03",
-  "formName" : "RP03 - Object to a request to rectify the register",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "RP06",
-  "formName" : "RP06 - Apply to remove material about a director",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "RP07",
-  "formName" : "RP07 - Apply to change a company's disputed registered office address",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [3]
-}, {
-  "_id" : "RPCH01",
-  "formName" : "RPCH01 - Correct a director's date of birth",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1,2]
-}, {
-  "_id" : "LLRP02A",
-  "formName" : "LL RP02A - Apply for rectification by the registrar for a limited liability partnership",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1,2]
-}, {
-  "_id" : "LLRP02B",
-  "formName" : "LL RP02B - Apply for rectification of change of registered address of a limited liability partnership",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LLRP03",
-  "formName" : "LL RP03 - Object to a request to rectify the register of a limited liability partnership",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LLRP07",
-  "formName" : "LL RP07 - Apply to change a disputed registered office address of a limited liability partnership",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [3]
-}, {
-  "_id" : "LLRPCH01",
-  "formName" : "RP LL CH01 - Correct the date of birth of an LLP member",
-  "formCategory" : "RP",
-  "fee" : "",
-  "isAuthenticationRequired" : false,
-  "isFesEnabled" : false,
-  "messageTextIdList": [1,2]
-}, {
-  "_id" : "CC01",
-  "formName" : "CC01 - Give notice of restriction on the company's articles",
-  "formCategory" : "CC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "CC02",
-  "formName" : "CC02 - Give notice of removal of restriction on company's articles",
-  "formCategory" : "CC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,2]
-}, {
-  "_id" : "CC04",
-  "formName" : "CC04 - Notify the change of company's objects",
-  "formCategory" : "CC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "CC05",
-  "formName" : "CC05 - Change constitution by enactment",
-  "formCategory" : "CC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "CC06",
-  "formName" : "CC06 - Change constitution by order of court or other authority",
-  "formCategory" : "CC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MA",
-  "formName" : "Articles",
-  "formCategory" : "CC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "RESOLUTIONS",
-  "formName" : "Resolution",
-  "formCategory" : "CC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT01",
-  "formName" : "MT01 - Notice that moratorium has come into force",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT02",
-  "formName" : "MT02 - Notice that moratorium has ended or been extended",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT03",
-  "formName" : "MT03 - Notice of early end of moratorium",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT04",
-  "formName" : "MT04 - Notice of end of moratorium by a monitor",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT05",
-  "formName" : "MT05 - Notice of end of moratorium by a court",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT06",
-  "formName" : "MT06 - Notice of end of moratorium following disposal of application for extension by the court or following CVA proposal taking effect or being withdrawn",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT07",
-  "formName" : "MT07 - Court order permitting disposal of property or goods",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT08",
-  "formName" : "MT08 - Notice of replacement or additional monitor following court order",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "MT09",
-  "formName" : "MT09 - Notice of monitor ceasing to act following court order",
-  "formCategory" : "CIGA2000",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "1.1",
-  "formName" : "1.1 - Notice of voluntary arrangement taking effect",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.1(Scot)",
-  "formName" : "1.1 (Scotland) - Notice of voluntary arrangement taking effect",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.11",
-  "formName" : "1.11 - Notice of commencement of moratorium",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.11(Scot)",
-  "formName" : "1.11 (Scotland) - Notice of commencement of moratorium",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.12",
-  "formName" : "1.12 - Notice of extension or continuation of moratorium",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.12(Scot)",
-  "formName" : "1.12 (Scotland) - Notice of extension or continuation of moratorium",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.14",
-  "formName" : "1.14 - Notice of ending of moratorium",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.14(Scot)",
-  "formName" : "1.14 (Scotland) - Notice of ending of moratorium",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.16",
-  "formName" : "1.16 - Notice of withdrawal of nominee's consent to act",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.16(Scot)",
-  "formName" : "1.16 (Scotland) - Notice of withdrawal of nominee's consent to act",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.18",
-  "formName" : "1.18 - Notice of the appointment of a replacement nominee",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.18(Scot)",
-  "formName" : "1.18 (Scotland) - Notice of the appointment of a replacement nominee",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.2",
-  "formName" : "1.2 - Notice of order, revocation or suspension of voluntary arrangement",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.2(Scot)",
-  "formName" : "1.2 (Scotland) - Notice of order, revocation or suspension of voluntary arrangement",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.3",
-  "formName" : "1.3 - Notice of supervisor's abstract of receipts and payments",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.3(Scot)",
-  "formName" : "1.3 (Scotland) - Notice of supervisor’s abstract of receipts and payments",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.4",
-  "formName" : "1.4 - Notice of completion of voluntary arrangement",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.4(Scot)",
-  "formName" : "1.4 (Scotland) - Notice of completion of voluntary arrangement",
-  "formCategory" : "IA1986_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2(Scot)",
-  "formName" : "2 (Scotland) - Notice of the appointment of a receiver by a court",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.1(Scot)",
-  "formName" : "2.1 (Scotland) - Notice of petition for administration order",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.11(Scot)",
-  "formName" : "2.11 (Scotland) - Notice of order to deal with secured property",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.11B(Scot)",
-  "formName" : "2.11B (Scotland) - Notice of appointment of administrative receiver, receiver or manager",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.12(Scot)",
-  "formName" : "2.12 (Scotland) - Notice of variation of administration order",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.12B",
-  "formName" : "2.12B(CH) - Notice of administrator's appointment",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.15B(Scot)",
-  "formName" : "2.15B (Scotland) - Notice of statement of affairs",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.16B",
-  "formName" : "2.16B - Notice of statement of affairs",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.16B(Scot)",
-  "formName" : "2.16B (Scotland) - Statement of administrator's proposal",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.16BZ(Scot)",
-  "formName" : "2.16BZ (Scotland) - Notice of deemed approval of proposal",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.17B",
-  "formName" : "2.17B - Notice of a statement of administrator's proposals",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.17B(Scot)",
-  "formName" : "2.17B (Scotland) - Statement of administrator's revised proposal",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.18B",
-  "formName" : "2.18B(CH) - Notice of extension of time period",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.18B(Scot)",
-  "formName" : "2.18B (Scotland) - Notice of result of meeting of creditors",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.19B(Scot)",
-  "formName" : "2.19B (Scotland) - Notice of order to deal with secured property",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.2(Scot)",
-  "formName" : "2.2 (Scotland) - Notice of administration order",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.2B(Scot)",
-  "formName" : "2.2B (Scotland) - Notice of petition for administration order",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.20B(Scot)",
-  "formName" : "2.20B (Scotland) - Administrator's progress report",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.21B(Scot)",
-  "formName" : "2.21B (Scotland) - Notice of automatic end of administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.22B",
-  "formName" : "2.22B(CH) - Notice of administrator's revised proposals",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.22B(Scot)",
-  "formName" : "2.22B (Scotland) - Notice of extension of period of administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.23B",
-  "formName" : "2.23B(CH) - Notice of result of creditors' meeting",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.23B(Scot)",
-  "formName" : "2.23B (Scotland) - Notice of end of administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.24B",
-  "formName" : "2.24B(CH) - Notice of administrator’s progress report",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.24B(Scot)",
-  "formName" : "2.24B (Scotland) - Notice of court order ending administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.25B(Scot)",
-  "formName" : "2.25B (Scotland) - Notice of move from administration to creditors' voluntary liquidation",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.26B",
-  "formName" : "2.26B(CH) - Amend certificate of constitution of creditors’ committee",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.26B(Scot)",
-  "formName" : "2.26B (Scotland) - Notice of move from administration to dissolution",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.27B",
-  "formName" : "2.27B - Notice by administrator of a change in committee",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.27B(Scot)",
-  "formName" : "2.27B (Scotland) - Notice of court order in respect of date of dissolution",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.28B",
-  "formName" : "2.28B - Notice of order to deal with charged property",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.29B(Scot)",
-  "formName" : "2.29B (Scotland) - Notice of resignation by administrator",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.3(Scot)",
-  "formName" : "2.3 (Scotland) - Notice of dismissal of petition for administration order",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.3B(Scot)",
-  "formName" : "2.3B (Scotland) - Notice of dismissal of petition for administration order",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.30B",
-  "formName" : "2.30B(CH) - Notice of the automatic end of administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.30B(Scot)",
-  "formName" : "2.30B (Scotland) - Notice of vacation of office by administrator",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.31B",
-  "formName" : "2.31B - Notice of the extension of period of administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.31B(Scot)",
-  "formName" : "2.31B (Scotland) - Notice of appointment of replacement/additional administrator",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.32B",
-  "formName" : "2.32B(CH) - Notice of the end of administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.32B(Scot)",
-  "formName" : "2.32B (Scotland) - Notice of insufficient property for distribution to unsecured creditors other than by virtue",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.33B",
-  "formName" : "2.33B - Notice of court order ending administration",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.34B",
-  "formName" : "2.34B - Notice of move from administration to creditors’ voluntary liquidation",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.35B",
-  "formName" : "2.35B - Notice of move from administration to dissolution",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.36B",
-  "formName" : "2.36B - Notice to registrar of companies in respect of date of dissolution",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.38B",
-  "formName" : "2.38B(CH) - Notice of resignation by administrator",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.39B",
-  "formName" : "2.39B - Notice of vacation of office by administrator",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.4(Scot)",
-  "formName" : "2.4 (Scotland) - Notice of discharge of administration order",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.40B",
-  "formName" : "2.40B - Notice of appointment of replacement/additional administrator",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.7(Scot)",
-  "formName" : "2.7 (Scotland) - Notice of statement of administrator's proposals",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.8(Scot)",
-  "formName" : "2.8 (Scotland) - Notice of result of meeting creditors",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.9(Scot)",
-  "formName" : "2.9 (Scotland) - Administrator's abstract of receipts and payments",
-  "formCategory" : "IA1986_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.3",
-  "formName" : "3.3 - Make statement of affairs in administrative receivership",
-  "formCategory" : "IA1986_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.6",
-  "formName" : "3.6(CH) - Notice of abstract of receipts and payments",
-  "formCategory" : "IA1986_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.7",
-  "formName" : "3.7 - Notice of administrative receiver's death",
-  "formCategory" : "IA1986_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.8",
-  "formName" : "3.8 - Notice of order to dispose of charged property",
-  "formCategory" : "IA1986_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.10",
-  "formName" : "3.10 - Notice of administrative receiver's report",
-  "formCategory" : "IA1986_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1(Scot)",
-  "formName" : "Form 1 (Scotland) - Notice of appointment of administrative receiver, receiver or manager",
-  "formCategory" : "IA1986_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "600",
-  "formName" : "600 (England and Wales) - Appoint liquidator in voluntary winding up",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.15A",
-  "formName" : "4.15A - Notice of appointment of provisional liquidator",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.17(Scot)",
-  "formName" : "4.17 (Scotland) - Notice of final account prior to dissolution in a winding up by the court",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.2(Scot)",
-  "formName" : "4.2 (Scotland) - Notice of winding up order",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.20",
-  "formName" : "4.20 - Make statement of company's affairs",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.27(Scot)",
-  "formName" : "4.27 (Scotland) - Notice of court order staying or sisting proceedings in a winding up by the court",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.31",
-  "formName" : "4.31 - Notice of appointment of liquidator",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.31(Scot)",
-  "formName" : "4.31 (Scotland) - Notice to registrar of companies in respect of order under section 176A",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.33",
-  "formName" : "4.33 - Notice of resignation as voluntary liquidator",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.35",
-  "formName" : "4.35 - Notice of court order granting liquidator to resign",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.38",
-  "formName" : "4.38 - Notice of removal of voluntary liquidator",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.40",
-  "formName" : "4.40 - Notice of ceasing to act as voluntary liquidator",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "F4.41",
-  "formName" : "F4.41 - Notice of the statement of affairs",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.43",
-  "formName" : "4.43 - Notice of the final meeting of creditors",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.44",
-  "formName" : "4.44 - Notice of the death of the voluntary liquidator",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.51",
-  "formName" : "4.51 - Notice by certificate that creditors paid in full",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.68",
-  "formName" : "4.68 - Notice of the liquidator's progress report",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.69",
-  "formName" : "4.69 - Notice of order of court on appeal",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.70",
-  "formName" : "4.70 - Declaration of solvency",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.71",
-  "formName" : "4.71 - Notice of final meeting in members' voluntary winding up",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.72",
-  "formName" : "4.72 - Notice of final meeting in creditors' voluntary winding up",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.9(Scot)",
-  "formName" : "4.9 (Scotland) - Notice of order of appointment of provisional liquidator in a winding up by the court",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "F10.2",
-  "formName" : "F10.2 - Notice of disclaimer under section 178 of Insolvency Act",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "12.1",
-  "formName" : "12.1 - Notice in respect of order under section 176a",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "F14",
-  "formName" : "F14 - Notice of a winding up order",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "L64.01",
-  "formName" : "L64.01 - Early completion of winding up",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "L64.04",
-  "formName" : "L64.04 - Deferment of dissolution (compulsory)",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "L64.07",
-  "formName" : "L64.07 - Completion of winding up",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "L72.18",
-  "formName" : "L72.18 - Winding up covering letter",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "COCOMP",
-  "formName" : "COCOMP - Order of court to wind up",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "COLIQ",
-  "formName" : "COLIQ - Deferment of dissolution",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "DETERMINAT",
-  "formName" : "DETERMINATION - Determination for LLPs",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "O/C DISCLOSE",
-  "formName" : "O/C DISCLOSE - Order of court limiting disclosure",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "O/C LTD DISCL",
-  "formName" : "O/C LTD DISCLOSE - Order of court limiting disclosure",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "O/C EARLY DISS",
-  "formName" : "O/C EARLY DISS - Order of court: early dissolution",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "O/C PROV RECALL",
-  "formName" : "O/C PROV RECALL - Order of court: recall of provisional liquidator",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "OCRESCIND",
-  "formName" : "O/C RESCIND - Order of court to rescind winding up",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "O/C STAY",
-  "formName" : "O/C STAY - Order of court to stay strike off",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "O/C UNSTAY",
-  "formName" : "O/C UNSTAY - Order of court to unstay strike off",
-  "formCategory" : "IA1986_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "NDISC",
-  "formName" : "NDISC - Notice of disclaimer under section 178 of the Insolvency Act 1986",
-  "formCategory" : "IA1986_NOD",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "NDISCA",
-  "formName" : "NDISCA - Notice attached to NDISC",
-  "formCategory" : "IA1986_NOD",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "VAM1",
-  "formName" : "VAM1 - Notice of the commencement of moratorium",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "VAM2",
-  "formName" : "VAM2 - Notice of continuation of moratorium",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "VAM3",
-  "formName" : "VAM3 - Notice of decision extending or further extending moratorium",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "VAM4",
-  "formName" : "VAM4 - Notice of a court order in relation to a moratorium",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "VAM5",
-  "formName" : "VAM5 - Notice of the withdrawal of nominee's consent to act",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "VAM6",
-  "formName" : "VAM6 - Notice of the appointment of a replacement nominee",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "VAM7",
-  "formName" : "VAM7 - Notice of the end of moratorium",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "VAMC",
-  "formName" : "VAMC - Notice of a court order in respect of a voluntary arrangement or moratorium",
-  "formCategory" : "INSEW2016_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "CVA1",
-  "formName" : "CVA1 - Notice of voluntary arrangement taking effect",
-  "formCategory" : "INSEW2016_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "CVA2",
-  "formName" : "CVA2 - Notice of order of revocation or suspension of voluntary arrangement",
-  "formCategory" : "INSEW2016_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1, 4]
-}, {
-  "_id" : "CVA3",
-  "formName" : "CVA3 - Notice of supervisor's progress report in voluntary arrangement",
-  "formCategory" : "INSEW2016_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "CVA4",
-  "formName" : "CVA4 - Notice of termination or full implementation of voluntary arrangement",
-  "formCategory" : "INSEW2016_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM01",
-  "formName" : "AM01 - Notice of administrator's appointment",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM02",
-  "formName" : "AM02 - Notice of statement of affairs in administration",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM03",
-  "formName" : "AM03 - Notice of administrator's proposals",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM04",
-  "formName" : "AM04 - Notice of the extension of time to deliver administrator's proposals",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM05",
-  "formName" : "AM05 - Notice of extension of time to seek approval",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM06",
-  "formName" : "AM06 - Notice of approval of administrator's proposals",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM07",
-  "formName" : "AM07 - Notice of creditor's decision on administrator's proposals",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM08",
-  "formName" : "AM08 - Notice of revision of administrator's proposals",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM09",
-  "formName" : "AM09 - Notice of result of creditor's decision",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM10",
-  "formName" : "AM10 - Notice of administrator's progress report",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM11",
-  "formName" : "AM11 - Notice of appointment of replacement or additional administrator",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM12",
-  "formName" : "AM12 - Notice of order limiting disclosure",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM13",
-  "formName" : "AM13 - Notice of rescission or amendment of order limiting disclosure",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM14",
-  "formName" : "AM14 - Notice of an order to dispose of charged property",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM15",
-  "formName" : "AM15 - Notice of resignation of administrator",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM16",
-  "formName" : "AM16 - Notice of order removing administrator from office",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM17",
-  "formName" : "AM17 - Notice of vacation of office",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM18",
-  "formName" : "AM18 - Notice of deceased administrator",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM19",
-  "formName" : "AM19 - Notice of the extension of period of administration",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "AM20",
-  "formName" : "AM20 - Notice of automatic end of administration",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM21",
-  "formName" : "AM21 - Notice of end of administration",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM22",
-  "formName" : "AM22 - Notice of a move from administration to creditors' voluntary liquidation",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM23",
-  "formName" : "AM23 - Notice of move from administration to dissolution",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM24",
-  "formName" : "AM24 - Notice of a court order in respect of date of dissolution",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM25",
-  "formName" : "AM25 - Notice of court order ending administration",
-  "formCategory" : "INSEW2016_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "REC1",
-  "formName" : "REC1 - Notice of administrative receiver's report",
-  "formCategory" : "INSEW2016_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "REC2",
-  "formName" : "REC2 - Notice of summary of receipts and payments",
-  "formCategory" : "INSEW2016_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "REC3",
-  "formName" : "REC3 - Notice of order of disposal of charged property",
-  "formCategory" : "INSEW2016_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "REC4",
-  "formName" : "REC4 - Notice of statement of affairs in administrative receivership",
-  "formCategory" : "INSEW2016_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "REC5",
-  "formName" : "REC5 - Notice of deceased administrative receiver",
-  "formCategory" : "INSEW2016_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "RM01",
-  "formName" : "RM01 - Notice of appointment of receiver or manager",
-  "formCategory" : "INSEW2016_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "RM02",
-  "formName" : "RM02 - Notice of ceasing to act as receiver or manager",
-  "formCategory" : "INSEW2016_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LIQ01",
-  "formName" : "LIQ01 - Notice of statutory declaration of solvency",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "LIQ02",
-  "formName" : "LIQ02 - Notice of statement of affairs",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "LIQ03",
-  "formName" : "LIQ03 - Notice of progress report in voluntary winding up",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "LIQ04",
-  "formName" : "LIQ04 - Notice of order deferring the date of dissolution in MVL or CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "LIQ05",
-  "formName" : "LIQ05 - Notice of order limiting disclosure of statement of affairs in CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "LIQ06",
-  "formName" : "LIQ06 - Notice of liquidator's resignation in MVL or CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LIQ07",
-  "formName" : "LIQ07 - Notice of removal of liquidator by creditors",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LIQ08",
-  "formName" : "LIQ08 - Notice of loss of qualification as insolvency practitioner in MVL and CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LIQ09",
-  "formName" : "LIQ09 - Notice of deceased liquidator in MVL and CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LIQ10",
-  "formName" : "LIQ10 - Notice of removal of liquidator by court in MVL and CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "LIQ11",
-  "formName" : "LIQ11 - Notice of removal of liquidator by company meeting in MVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LIQ12",
-  "formName" : "LIQ12 - Notice of release of former liquidator by secretary of state in MVL or CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "LIQ13",
-  "formName" : "LIQ13 - Notice of final account prior to dissolution in MVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "LIQ14",
-  "formName" : "LIQ14 - Notice of final account prior to dissolution in CVL",
-  "formCategory" : "INSEW2016_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "WU01",
-  "formName" : "WU01 - Notice of court order in a winding up",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "WU02",
-  "formName" : "WU02 - Notice of order of appointment of provisional liquidator",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "WU03",
-  "formName" : "WU03 - Notice of termination of appointment of provisional liquidator",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "WU04",
-  "formName" : "WU04 - Notice of the appointment of liquidator in a winding up by the court",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "WU07",
-  "formName" : "WU07 - Notice of a progress report in a winding up by the court",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "WU13",
-  "formName" : "WU13 - Notice of order of court on appeal against decision",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "WU14",
-  "formName" : "WU14 - Notice of an order for removal of liquidator",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "WU15",
-  "formName" : "WU15 - Notice of the final account prior to dissolution",
-  "formCategory" : "INSEW2016_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "COM1",
-  "formName" : "COM1 - Notice of establishment of creditors' or liquidation committee",
-  "formCategory" : "INSEW2016_COM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "COM2",
-  "formName" : "COM2 - Notice of change of membership of a creditors' or liquidation committee",
-  "formCategory" : "INSEW2016_COM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "COM3",
-  "formName" : "COM3 - Notice of continuation of creditors' committee",
-  "formCategory" : "INSEW2016_COM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "COM4",
-  "formName" : "COM4 - Notice of cessation of liquidation committee",
-  "formCategory" : "INSEW2016_COM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1]
-}, {
-  "_id" : "NOCP",
-  "formName" : "NOCP - Give notice of a court order under section 176A (5) ",
-  "formCategory" : "INSEW2016_EXP",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "AM01(Scot)",
-  "formName" : "AM01 (Scot) - Notice of administrator's appointment",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM02(Scot)",
-  "formName" : "AM02 (Scot) - Notice of statement of affairs in administration",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM03(Scot)",
-  "formName" : "AM03 (Scot) - Notice of administrator's proposals",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM04(Scot)",
-  "formName" : "AM04 (Scot) - Notice of the extension of time to deliver administrator's proposals",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM05(Scot)",
-  "formName" : "AM05 (Scot) - Notice of extension of time to seek approval",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM06(Scot)",
-  "formName" : "AM06 (Scot) - Notice of approval of administrator's proposals",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM07(Scot)",
-  "formName" : "AM07 (Scot) - Notice of creditor's decision on administrator's proposals",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM08(Scot)",
-  "formName" : "AM08 (Scot) - Notice of revision of administrator's proposals",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM09(Scot)",
-  "formName" : "AM09 (Scot) - Notice of result of a creditor's decision",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM10(Scot)",
-  "formName" : "AM10 (Scot) - Notice of administrator's progress report",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM11(Scot)",
-  "formName" : "AM11 (Scot) - Appoint a replacement or additional administrator",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM12(Scot)",
-  "formName" : "AM12 (Scot) - Notice of order limiting disclosure",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM13(Scot)",
-  "formName" : "AM13 (Scot) - Rescission or amendment of order limiting disclosure",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM14(Scot)",
-  "formName" : "AM14 (Scot) - Notice of an order to dispose of charged property",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM15(Scot)",
-  "formName" : "AM15 (Scot) - Resignation of administrator",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM16(Scot)",
-  "formName" : "AM16 (Scot) - Notice of order removing administrator from office",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM17(Scot)",
-  "formName" : "AM17 (Scot) - Notice of vacation of office",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM18(Scot)",
-  "formName" : "AM18 (Scot) - Notice of a deceased administrator",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM19(Scot)",
-  "formName" : "AM19 (Scot) - Extend the period of administration",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM20(Scot)",
-  "formName" : "AM20 (Scot) - Notice of automatic end of administration",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM21(Scot)",
-  "formName" : "AM21 (Scot) - Notice of end of administration",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM22(Scot)",
-  "formName" : "AM22 (Scot) - Move a Scottish company from administration to creditors' voluntary liquidation",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM23(Scot)",
-  "formName" : "AM23 (Scot) - Move a Scottish company from administration to dissolution",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM24(Scot)",
-  "formName" : "AM24 (Scot) - Notice of a court order in respect of date of dissolution",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AM25(Scot)",
-  "formName" : "AM25 (Scot) - Notice of court order ending administration",
-  "formCategory" : "INSSC2018_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "COM1(Scot)",
-  "formName" : "COM1 (Scot) - Notice of establishment of creditors’ committee (administration)",
-  "formCategory" : "INSSC2018_COM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "COM2(Scot)",
-  "formName" : "COM2 (Scot) - Notice of change of membership of a creditors’ committee (administration)",
-  "formCategory" : "INSSC2018_COM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "CVA1(Scot)",
-  "formName" : "CVA1 (Scot) - Notice of voluntary arrangement taking effect",
-  "formCategory" : "INSSC2018_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "CVA2(Scot)",
-  "formName" : "CVA2 (Scot) - Notice of an order of revocation or suspension of voluntary arrangement",
-  "formCategory" : "INSSC2018_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "CVA3(Scot)",
-  "formName" : "CVA3 (Scot) - Notice of a supervisor's progress report in voluntary arrangement",
-  "formCategory" : "INSSC2018_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "CVA4(Scot)",
-  "formName" : "CVA4 (Scot) - Terminate or fully implement voluntary arrangement",
-  "formCategory" : "INSSC2018_CVA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM1(Scot)",
-  "formName" : "VAM1 (Scot) - Notice of the commencement of moratorium",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM2(Scot)",
-  "formName" : "VAM2 (Scot) - Notice of continuation of moratorium",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM3(Scot)",
-  "formName" : "VAM3 (Scot) - Notice of decision extending or further extending moratorium",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM4(Scot)",
-  "formName" : "VAM4 (Scot) - Notice of a court order in relation to a moratorium",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM5(Scot)",
-  "formName" : "VAM5 (Scot) - Withdrawal of nominee's consent to act",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM6(Scot)",
-  "formName" : "VAM6 (Scot) - Appoint a replacement nominee",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM7(Scot)",
-  "formName" : "VAM7 (Scot) - Notice of the end of moratorium",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAM8(Scot)",
-  "formName" : "VAM8 (Scot) - Notice of disposal of charged property during a moratorium",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VAMC(Scot)",
-  "formName" : "VAMC (Scot) - Notice of a court order in respect of a voluntary arrangement or moratorium",
-  "formCategory" : "INSSC2018_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "NOCP(Scot)",
-  "formName" : "NOCP (Scot) - Notice of a court order under section 176A(5)",
-  "formCategory" : "INSSC2018_EXP",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LIQ04(Scot)",
-  "formName" : "LIQ04 (Scot) - Notice of order deferring the date of dissolution",
-  "formCategory" : "INSSC2018_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LIQ13(Scot)",
-  "formName" : "LIQ13 (Scot) - Final account prior to dissolution in MVL",
-  "formCategory" : "INSSC2018_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LIQ14(Scot)",
-  "formName" : "LIQ14 (Scot) - Final account prior to dissolution in CVL",
-  "formCategory" : "INSSC2018_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LIQ15(Scot)",
-  "formName" : "LIQ15 (Scot) - Notice of a court order staying or sisting proceedings in a CVL or MVL winding up",
-  "formCategory" : "INSSC2018_VL",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "REC1(Scot)",
-  "formName" : "REC1 (Scot) - Notice of receiver's report",
-  "formCategory" : "INSSC2018_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "REC3(Scot)",
-  "formName" : "REC3 (Scot) - Notice of authorisation to dispose of secured property in receivership",
-  "formCategory" : "INSSC2018_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "REC5(Scot)",
-  "formName" : "REC5 (Scot) - Notice of a deceased receiver",
-  "formCategory" : "INSSC2018_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "RECSOA(Scot)",
-  "formName" : "RECSOA (Scot) - Statement of affairs",
-  "formCategory" : "INSSC2018_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "RM01(Scot)",
-  "formName" : "RM01 (Scot) - Notice of appointment of a receiver",
-  "formCategory" : "INSSC2018_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "RM02(Scot)",
-  "formName" : "RM02 (Scot) - Notice of ceasing to act as a receiver",
-  "formCategory" : "INSSC2018_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "WU01(Scot)",
-  "formName" : "WU01 (Scot) - Notice of a court order in a winding up",
-  "formCategory" : "INSSC2018_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "WU02(Scot)",
-  "formName" : "WU02 (Scot) - Notice of order of appointment of a provisional liquidator",
-  "formCategory" : "INSSC2018_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "WU03(Scot)",
-  "formName" : "WU03 (Scot) - Notice of termination of appointment of provisional liquidator",
-  "formCategory" : "INSSC2018_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "WU15(Scot)",
-  "formName" : "WU15 (Scot) - Notice of the final account prior to the dissolution",
-  "formCategory" : "INSSC2018_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "WU16(Scot)",
-  "formName" : "WU16 (Scot) - Early dissolution of a Scottish company in a winding up by the court",
-  "formCategory" : "INSSC2018_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "WU17(Scot)",
-  "formName" : "WU17 (Scot) - Defer the dissolution of a Scottish company in a winding up by the court",
-  "formCategory" : "INSSC2018_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "WU18(Scot)",
-  "formName" : "WU18 (Scot) - Notice of a court order staying or sisting proceedings in a winding up order by the court",
-  "formCategory" : "INSSC2018_WU",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.1(NI)",
-  "formName" : "1.1 - Notice of voluntary arrangement taking effect",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.11(NI)",
-  "formName" : "1.11 - Notice of commencement of moratorium",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.12(NI)",
-  "formName" : "1.12 - Notice of extension or continuation of moratorium",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.14(NI)",
-  "formName" : "1.14 - Notice of ending of moratorium",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.16(NI)",
-  "formName" : "1.16 - Notice of withdrawal of nominee's consent to act",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.18(NI)",
-  "formName" : "1.18 - Notice of the appointment of a replacement nominee",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.2(NI)",
-  "formName" : "1.2 - Notice of order, revocation or suspension of voluntary arrangement",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.3(NI)",
-  "formName" : "1.3 - Notice of supervisor’s abstract of receipts and payments",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "1.4(NI)",
-  "formName" : "1.4 - Notice of completion of voluntary arrangement",
-  "formCategory" : "INIO1989_CVAM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.07(NI)",
-  "formName" : "2.07 - Notice of administration order",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.08(NI)",
-  "formName" : "2.08 - Administration order",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.12B(NI)",
-  "formName" : "2.12B - Notice of administrator's appointment",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.14B(NI)",
-  "formName" : "2.14B - Statement of affairs",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.15B(NI)",
-  "formName" : "2.15B - Statement of concurrence",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.16(NI)",
-  "formName" : "2.16 - Administrator's abstracts",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.16B(NI)",
-  "formName" : "2.16B - Notice of statement of affairs",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.17B(NI)",
-  "formName" : "2.17B - Statement of administrator's proposals",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.18B(NI)",
-  "formName" : "2.18B - Notice of extension of time period",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.18BA(NI)",
-  "formName" : "2.18BA - Notice of deemed approval of proposals",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.19(NI)",
-  "formName" : "2.19 - Notice of order to deal with charged property",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.20(NI)",
-  "formName" : "2.20 - Notice of discharge of administration order",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.21(NI)",
-  "formName" : "2.21 - Notice of variation of administration order",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.22(NI)",
-  "formName" : "2.22 - Statement of administrator's proposals",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.22B(NI)",
-  "formName" : "2.22B - Statement of administrator's revised proposals",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.23B(NI)",
-  "formName" : "2.23B - Notice of result of creditors’ meeting",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.24(NI)",
-  "formName" : "2.24 - Notice of result of meeting of creditors",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.24B(NI)",
-  "formName" : "2.24B - Notice of administrator’s progress report",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.26B(NI)",
-  "formName" : "2.26B - Amend certificate of constitution of creditors’ committee",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.27B(NI)",
-  "formName" : "2.27B - Notice by administrator of a change in committee membership",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.28B(NI)",
-  "formName" : "2.28B - Notice of order to deal with charged property",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.30B(NI)",
-  "formName" : "2.30B - Notice of automatic end of administration",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.31B(NI)",
-  "formName" : "2.31B - Notice of the extension period of administration",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.32B(NI)",
-  "formName" : "2.32B - Notice of end of administration",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.33B(NI)",
-  "formName" : "2.33B - Notice of court order ending administration",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.34B(NI)",
-  "formName" : "2.34B - Notice of move from administration to creditors’ voluntary liquidation",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.35B(NI)",
-  "formName" : "2.35B - Notice of move from administration to dissolution",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.36B(NI)",
-  "formName" : "2.36B - Notice to registrar of companies in respect of date of dissolution",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.38B(NI)",
-  "formName" : "2.38B - Notice of resignation by administrator",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.39B(NI)",
-  "formName" : "2.39B - Notice of vacation of office by administrator",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.4(NI)",
-  "formName" : "2.4 - Notice of appointment of replacement/additional administrator",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "2.40B(NI)",
-  "formName" : "2.40B - Notice of appointment of replacement/additional administrator",
-  "formCategory" : "INIO1989_ADM",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.04(NI)",
-  "formName" : "3.04 - Statement of affairs receivership",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.05(NI)",
-  "formName" : "3.05 - Statement of affairs in administrative receivership following report to creditors",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.06(NI)",
-  "formName" : "3.06 - Certificate of constitution (amended certificate) of creditors' committee",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.07(NI)",
-  "formName" : "3.07 - Administrative receiver's report as to change in membership of creditors' committee",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.08(NI)",
-  "formName" : "3.08 - Receiver or manager or administrative receiver's abstract of receipts and payment",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.09(NI)",
-  "formName" : "3.09 - Notice of administrative receiver's death",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.10(NI)",
-  "formName" : "3.10 - Notice of order to dispose of charged property",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3.12(NI)",
-  "formName" : "3.12 - Administrative receiver's report",
-  "formCategory" : "INIO1989_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LRESC(NI)",
-  "formName" : "Creditors' voluntary liquidation resolution",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LRESM(NI)",
-  "formName" : "Members' voluntary liquidation resolution",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "L21(NI)",
-  "formName" : "L21 - Early completion of winding up",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "L22(NI)",
-  "formName" : "L22 - Completion of winding up",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "L131(NI)",
-  "formName" : "L131 - Deferment of dissolution (compulsory)",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "VL1",
-  "formName" : "VL1 - Notice of appointment of liquidator: voluntary winding up (members or creditors)",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.16(NI)",
-  "formName" : "4.16 - Notice of appointment of provisional liquidator",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.16A(NI)",
-  "formName" : "4.16A - Notice of appointment of provisional liquidator in winding up by the court",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.19(NI)",
-  "formName" : "4.19 - Statement of affairs: voluntary liquidation",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.21(NI)",
-  "formName" : "4.21 - Statement of affairs",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.23(NI)",
-  "formName" : "4.23 - Deferment of dissolution",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.26(NI)",
-  "formName" : "4.26 - Proof of debt",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.32(NI)",
-  "formName" : "4.32 - Notice of appointment of a liquidator in winding up by the court",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.34(NI)",
-  "formName" : "4.34 - Notice of resignation as voluntary liquidator under Article 145(5) of the Insolvency (Northern Ireland) Order 1989",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.36(NI)",
-  "formName" : "4.36 - Notice of order of court granting liquidator leave to resign",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.39(NI)",
-  "formName" : "4.39 - Certificate of removal of voluntary liquidator",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.41(NI)",
-  "formName" : "4.41 - Notice of ceasing to act as voluntary liquidator",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.44(NI)",
-  "formName" : "4.44 - Notice of final meeting of creditors",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.45(NI)",
-  "formName" : "4.45 - Notice of death of voluntary liquidator",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.47(NI)",
-  "formName" : "4.47 - Notice of vacation of office by voluntary liquidator",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.52(NI)",
-  "formName" : "4.52 - Certificate that creditors have been paid in full",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.53(NI)",
-  "formName" : "4.53 - Liquidator's certificate of continuance of liquidation committee",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.69(NI)",
-  "formName" : "4.69 - Liquidator's statement of receipts and payments",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.70(NI)",
-  "formName" : "4.70 - Order of court on appeal against secretary of state's decision",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.71(NI)",
-  "formName" : "4.71 - Declaration of solvency",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.72(NI)",
-  "formName" : "4.72 - Return of final meeting in a members' voluntary winding up",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "4.73(NI)",
-  "formName" : "4.73 - Return of final meeting in a creditors' voluntary winding up",
-  "formCategory" : "INIO1989_LIQ",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "OSDS02",
-  "formName" : "OS DS02 - Termination of overseas company insolvency proceedings",
-  "formCategory" : "OCR2009",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "OSLQ01",
-  "formName" : "OS LQ01 - Appointment of liquidator of overseas company",
-  "formCategory" : "OCR2009",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "OSLQ02",
-  "formName" : "OS LQ02 - Insolvency proceedings against overseas company",
-  "formCategory" : "OCR2009",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "OSLQ03",
-  "formName" : "OS LQ03 - Notice of winding up of an overseas company",
-  "formCategory" : "OCR2009",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "OSLQ04",
-  "formName" : "OS LQ04 - Cessation of overseas company subject to insolvency proceedings",
-  "formCategory" : "OCR2009",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LLRM01",
-  "formName" : "LL RM01 - Notice of appointment of an administrative receiver, receiver or manager",
-  "formCategory" : "LLPR2009",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LLRM02",
-  "formName" : "LL RM02 - Notice of ceasing to act as an administrative receiver, receiver or manager",
-  "formCategory" : "LLPR2009",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LRESEX",
-  "formName" : "Extraordinary resolution to wind up (creditors' voluntary liquidation)",
-  "formCategory" : "INS_RES",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "LRESSP",
-  "formName" : "Special resolution to wind up (members' voluntary liquidation)",
-  "formCategory" : "INS_RES",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "3(Scot)",
-  "formName" : "Form 3 (Scotland) - Cease to act as administrative receiver, receiver or manager",
-  "formCategory" : "IA1986_REC",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true
-}, {
-  "_id" : "AD01",
-  "formName" : "AD01 – Change a company’s registered office address",
-  "formCategory" : "INSCROA",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH02",
-  "formName" : "SH02 - Consolidate, sub-divide, redeem shares or re-convert stock into shares",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH04",
-  "formName" : "SH04 - Notify a sale or transfer of treasury shares",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH05",
-  "formName" : "SH05 - Notify a cancellation of treasury shares",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH06",
-  "formName" : "SH06 - Notify a cancellation of shares",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4,5]
-}, {
-  "_id" : "SH07",
-  "formName" : "SH07 - Notify a cancellation of shares held by or for a public company",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH08",
-  "formName" : "SH08 - Notify a name or other designation of class of shares",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH09",
-  "formName" : "SH09 - Allotting a new class of shares by an unlimited company",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH10",
-  "formName" : "SH10 - Give notice of particulars of variation of rights attached to shares",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH11",
-  "formName" : "SH11 - Give notice of a new class of members",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH12",
-  "formName" : "SH12 - Give notice of particulars of variation of class rights",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH13",
-  "formName" : "SH13 - Give notice of name or other designation of class of members",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH14",
-  "formName" : "SH14 - Notify a redenomination of shares",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH15",
-  "formName" : "SH15 - Notify a reduction of capital following redenomination",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH16",
-  "formName" : "SH16 - Give notice of application to court to cancel special resolution",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-}, {
-  "_id" : "SH17",
-  "formName" : "SH17 - Give notice by the company of application to cancel special resolution",
-  "formCategory" : "SH",
-  "fee" : "",
-  "isAuthenticationRequired" : true,
-  "isFesEnabled" : true,
-  "messageTextIdList": [1,4]
-} ]
+[
+  {
+    "_id": {
+      "formType": "SLPCS01",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP CS01 - Confirmation statement for a Scottish limited partnership",
+    "fee": "SLPCS01",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC01",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC01 - Give notice of individual person with significant control of a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC02",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC02 - Give notice of relevant legal entity with significant control of a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC03",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC03 - Give notice of other registrable person with significant control of a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC04",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC04 - Give notice to change details of a person with significant control of a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC05",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC05 - Give details of relevant legal entity with significant control of a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC06",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC06 - Give notice changing details of other person with significant control of a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC07",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC07 - Give notice of ceasing to be a PSC, RLE or ORP of a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC08",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC08 - Give notice of a person of PSC statements for a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SLPPSC09",
+      "formCategory": "SLP"
+    },
+    "formName": "SLP PSC09 - Give notice of update to PSC statements for a Scottish limited partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPCS01",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP CS01 - Confirmation statement for a Scottish qualifying partnership",
+    "fee": "SQPCS01",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQP2",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP2 - Give notice of a change of details for a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQP3",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP3 - Give notice of ceasing to be a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC01",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC01 - Give notice of individual person with significant control of a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC02",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC02 - Give notice of relevant legal entity with significant control of a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC03",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC03 - Give notice of other registrable person with significant control of a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC04",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC04 - Give notice to change details of a person with significant control of a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC05",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC05 - Give details of relevant legal entity with significant control of a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC06",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC06 - Give notice changing details of other person with significant control of a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC07",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC07 - Give notice of ceasing to be a PSC, RLE or ORP of a Scottish Qualifying Partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC08",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC08 - Give notice of PSC statements for a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SQPPSC09",
+      "formCategory": "SQP"
+    },
+    "formName": "SQP PSC09 - Give notice of update to PSC statements for a Scottish qualifying partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RP02A",
+      "formCategory": "RP"
+    },
+    "formName": "RP02A - Apply for rectification by the registrar of companies",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1,
+      2
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RP02B",
+      "formCategory": "RP"
+    },
+    "formName": "RP02B - Apply for rectification for a change of registered address",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RP03",
+      "formCategory": "RP"
+    },
+    "formName": "RP03 - Object to a request to rectify the register",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RP06",
+      "formCategory": "RP"
+    },
+    "formName": "RP06 - Apply to remove material about a director",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RP07",
+      "formCategory": "RP"
+    },
+    "formName": "RP07 - Apply to change a company's disputed registered office address",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      3
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RPCH01",
+      "formCategory": "RP"
+    },
+    "formName": "RPCH01 - Correct a director's date of birth",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1,
+      2
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LLRP02A",
+      "formCategory": "RP"
+    },
+    "formName": "LL RP02A - Apply for rectification by the registrar for a limited liability partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1,
+      2
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LLRP02B",
+      "formCategory": "RP"
+    },
+    "formName": "LL RP02B - Apply for rectification of change of registered address of a limited liability partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LLRP03",
+      "formCategory": "RP"
+    },
+    "formName": "LL RP03 - Object to a request to rectify the register of a limited liability partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LLRP07",
+      "formCategory": "RP"
+    },
+    "formName": "LL RP07 - Apply to change a disputed registered office address of a limited liability partnership",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      3
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LLRPCH01",
+      "formCategory": "RP"
+    },
+    "formName": "RP LL CH01 - Correct the date of birth of an LLP member",
+    "fee": "",
+    "isAuthenticationRequired": false,
+    "isFesEnabled": false,
+    "messageTextIdList": [
+      1,
+      2
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CC01",
+      "formCategory": "CC"
+    },
+    "formName": "CC01 - Give notice of restriction on the company's articles",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CC02",
+      "formCategory": "CC"
+    },
+    "formName": "CC02 - Give notice of removal of restriction on company's articles",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      2
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CC04",
+      "formCategory": "CC"
+    },
+    "formName": "CC04 - Notify the change of company's objects",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CC05",
+      "formCategory": "CC"
+    },
+    "formName": "CC05 - Change constitution by enactment",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CC06",
+      "formCategory": "CC"
+    },
+    "formName": "CC06 - Change constitution by order of court or other authority",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MA",
+      "formCategory": "CC"
+    },
+    "formName": "Articles",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RESOLUTIONS",
+      "formCategory": "CC"
+    },
+    "formName": "Resolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT01",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT01 - Notice that moratorium has come into force",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT02",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT02 - Notice that moratorium has ended or been extended",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT03",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT03 - Notice of early end of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT04",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT04 - Notice of end of moratorium by a monitor",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT05",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT05 - Notice of end of moratorium by a court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT06",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT06 - Notice of end of moratorium following disposal of application for extension by the court or following CVA proposal taking effect or being withdrawn",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT07",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT07 - Court order permitting disposal of property or goods",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT08",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT08 - Notice of replacement or additional monitor following court order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "MT09",
+      "formCategory": "CIGA2000"
+    },
+    "formName": "MT09 - Notice of monitor ceasing to act following court order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "1.1",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.1 - Notice of voluntary arrangement taking effect",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.1(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.1 (Scotland) - Notice of voluntary arrangement taking effect",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.11",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.11 - Notice of commencement of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.11(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.11 (Scotland) - Notice of commencement of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.12",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.12 - Notice of extension or continuation of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.12(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.12 (Scotland) - Notice of extension or continuation of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.14",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.14 - Notice of ending of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.14(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.14 (Scotland) - Notice of ending of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.16",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.16 - Notice of withdrawal of nominee's consent to act",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.16(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.16 (Scotland) - Notice of withdrawal of nominee's consent to act",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.18",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.18 - Notice of the appointment of a replacement nominee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.18(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.18 (Scotland) - Notice of the appointment of a replacement nominee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.2",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.2 - Notice of order, revocation or suspension of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.2(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.2 (Scotland) - Notice of order, revocation or suspension of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.3",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.3 - Notice of supervisor's abstract of receipts and payments",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.3(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.3 (Scotland) - Notice of supervisor’s abstract of receipts and payments",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.4",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.4 - Notice of completion of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.4(Scot)",
+      "formCategory": "IA1986_CVAM"
+    },
+    "formName": "1.4 (Scotland) - Notice of completion of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2 (Scotland) - Notice of the appointment of a receiver by a court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.1(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.1 (Scotland) - Notice of petition for administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.11(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.11 (Scotland) - Notice of order to deal with secured property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.11B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.11B (Scotland) - Notice of appointment of administrative receiver, receiver or manager",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.12(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.12 (Scotland) - Notice of variation of administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.12B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.12B(CH) - Notice of administrator's appointment",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.15B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.15B (Scotland) - Notice of statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.16B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.16B - Notice of statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.16B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.16B (Scotland) - Statement of administrator's proposal",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.16BZ(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.16BZ (Scotland) - Notice of deemed approval of proposal",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.17B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.17B - Notice of a statement of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.17B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.17B (Scotland) - Statement of administrator's revised proposal",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.18B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.18B(CH) - Notice of extension of time period",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.18B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.18B (Scotland) - Notice of result of meeting of creditors",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.19B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.19B (Scotland) - Notice of order to deal with secured property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.2(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.2 (Scotland) - Notice of administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.2B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.2B (Scotland) - Notice of petition for administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.20B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.20B (Scotland) - Administrator's progress report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.21B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.21B (Scotland) - Notice of automatic end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.22B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.22B(CH) - Notice of administrator's revised proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.22B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.22B (Scotland) - Notice of extension of period of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.23B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.23B(CH) - Notice of result of creditors' meeting",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.23B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.23B (Scotland) - Notice of end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.24B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.24B(CH) - Notice of administrator’s progress report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.24B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.24B (Scotland) - Notice of court order ending administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.25B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.25B (Scotland) - Notice of move from administration to creditors' voluntary liquidation",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.26B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.26B(CH) - Amend certificate of constitution of creditors’ committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.26B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.26B (Scotland) - Notice of move from administration to dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.27B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.27B - Notice by administrator of a change in committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.27B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.27B (Scotland) - Notice of court order in respect of date of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.28B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.28B - Notice of order to deal with charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.29B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.29B (Scotland) - Notice of resignation by administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.3(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.3 (Scotland) - Notice of dismissal of petition for administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.3B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.3B (Scotland) - Notice of dismissal of petition for administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.30B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.30B(CH) - Notice of the automatic end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.30B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.30B (Scotland) - Notice of vacation of office by administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.31B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.31B - Notice of the extension of period of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.31B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.31B (Scotland) - Notice of appointment of replacement/additional administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.32B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.32B(CH) - Notice of the end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.32B(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.32B (Scotland) - Notice of insufficient property for distribution to unsecured creditors other than by virtue",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.33B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.33B - Notice of court order ending administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.34B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.34B - Notice of move from administration to creditors’ voluntary liquidation",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.35B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.35B - Notice of move from administration to dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.36B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.36B - Notice to registrar of companies in respect of date of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.38B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.38B(CH) - Notice of resignation by administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.39B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.39B - Notice of vacation of office by administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.4(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.4 (Scotland) - Notice of discharge of administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.40B",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.40B - Notice of appointment of replacement/additional administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.7(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.7 (Scotland) - Notice of statement of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.8(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.8 (Scotland) - Notice of result of meeting creditors",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.9(Scot)",
+      "formCategory": "IA1986_ADM"
+    },
+    "formName": "2.9 (Scotland) - Administrator's abstract of receipts and payments",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.3",
+      "formCategory": "IA1986_REC"
+    },
+    "formName": "3.3 - Make statement of affairs in administrative receivership",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.6",
+      "formCategory": "IA1986_REC"
+    },
+    "formName": "3.6(CH) - Notice of abstract of receipts and payments",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.7",
+      "formCategory": "IA1986_REC"
+    },
+    "formName": "3.7 - Notice of administrative receiver's death",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.8",
+      "formCategory": "IA1986_REC"
+    },
+    "formName": "3.8 - Notice of order to dispose of charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.10",
+      "formCategory": "IA1986_REC"
+    },
+    "formName": "3.10 - Notice of administrative receiver's report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1(Scot)",
+      "formCategory": "IA1986_REC"
+    },
+    "formName": "Form 1 (Scotland) - Notice of appointment of administrative receiver, receiver or manager",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "600",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "600 (England and Wales) - Appoint liquidator in voluntary winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.15A",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.15A - Notice of appointment of provisional liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.17(Scot)",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.17 (Scotland) - Notice of final account prior to dissolution in a winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.2(Scot)",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.2 (Scotland) - Notice of winding up order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.20",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.20 - Make statement of company's affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.27(Scot)",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.27 (Scotland) - Notice of court order staying or sisting proceedings in a winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.31",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.31 - Notice of appointment of liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.31(Scot)",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.31 (Scotland) - Notice to registrar of companies in respect of order under section 176A",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.33",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.33 - Notice of resignation as voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.35",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.35 - Notice of court order granting liquidator to resign",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.38",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.38 - Notice of removal of voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.40",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.40 - Notice of ceasing to act as voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "F4.41",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "F4.41 - Notice of the statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.43",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.43 - Notice of the final meeting of creditors",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.44",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.44 - Notice of the death of the voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.51",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.51 - Notice by certificate that creditors paid in full",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.68",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.68 - Notice of the liquidator's progress report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.69",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.69 - Notice of order of court on appeal",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.70",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.70 - Declaration of solvency",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.71",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.71 - Notice of final meeting in members' voluntary winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.72",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.72 - Notice of final meeting in creditors' voluntary winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.9(Scot)",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "4.9 (Scotland) - Notice of order of appointment of provisional liquidator in a winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "F10.2",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "F10.2 - Notice of disclaimer under section 178 of Insolvency Act",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "12.1",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "12.1 - Notice in respect of order under section 176a",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "F14",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "F14 - Notice of a winding up order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "L64.01",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "L64.01 - Early completion of winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "L64.04",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "L64.04 - Deferment of dissolution (compulsory)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "L64.07",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "L64.07 - Completion of winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "L72.18",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "L72.18 - Winding up covering letter",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "COCOMP",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "COCOMP - Order of court to wind up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "COLIQ",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "COLIQ - Deferment of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "DETERMINAT",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "DETERMINATION - Determination for LLPs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "O/C DISCLOSE",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "O/C DISCLOSE - Order of court limiting disclosure",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "O/C LTD DISCL",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "O/C LTD DISCLOSE - Order of court limiting disclosure",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "O/C EARLY DISS",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "O/C EARLY DISS - Order of court: early dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "O/C PROV RECALL",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "O/C PROV RECALL - Order of court: recall of provisional liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "OCRESCIND",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "O/C RESCIND - Order of court to rescind winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "O/C STAY",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "O/C STAY - Order of court to stay strike off",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "O/C UNSTAY",
+      "formCategory": "IA1986_LIQ"
+    },
+    "formName": "O/C UNSTAY - Order of court to unstay strike off",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "NDISC",
+      "formCategory": "IA1986_NOD"
+    },
+    "formName": "NDISC - Notice of disclaimer under section 178 of the Insolvency Act 1986",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "NDISCA",
+      "formCategory": "IA1986_NOD"
+    },
+    "formName": "NDISCA - Notice attached to NDISC",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAM1",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAM1 - Notice of the commencement of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAM2",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAM2 - Notice of continuation of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAM3",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAM3 - Notice of decision extending or further extending moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAM4",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAM4 - Notice of a court order in relation to a moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAM5",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAM5 - Notice of the withdrawal of nominee's consent to act",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAM6",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAM6 - Notice of the appointment of a replacement nominee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAM7",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAM7 - Notice of the end of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "VAMC",
+      "formCategory": "INSEW2016_CVAM"
+    },
+    "formName": "VAMC - Notice of a court order in respect of a voluntary arrangement or moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CVA1",
+      "formCategory": "INSEW2016_CVA"
+    },
+    "formName": "CVA1 - Notice of voluntary arrangement taking effect",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CVA2",
+      "formCategory": "INSEW2016_CVA"
+    },
+    "formName": "CVA2 - Notice of order of revocation or suspension of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CVA3",
+      "formCategory": "INSEW2016_CVA"
+    },
+    "formName": "CVA3 - Notice of supervisor's progress report in voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "CVA4",
+      "formCategory": "INSEW2016_CVA"
+    },
+    "formName": "CVA4 - Notice of termination or full implementation of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM01",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM01 - Notice of administrator's appointment",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM02",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM02 - Notice of statement of affairs in administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM03",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM03 - Notice of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM04",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM04 - Notice of the extension of time to deliver administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM05",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM05 - Notice of extension of time to seek approval",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM06",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM06 - Notice of approval of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM07",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM07 - Notice of creditor's decision on administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM08",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM08 - Notice of revision of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM09",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM09 - Notice of result of creditor's decision",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM10",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM10 - Notice of administrator's progress report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM11",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM11 - Notice of appointment of replacement or additional administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM12",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM12 - Notice of order limiting disclosure",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM13",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM13 - Notice of rescission or amendment of order limiting disclosure",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM14",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM14 - Notice of an order to dispose of charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM15",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM15 - Notice of resignation of administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM16",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM16 - Notice of order removing administrator from office",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM17",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM17 - Notice of vacation of office",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM18",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM18 - Notice of deceased administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM19",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM19 - Notice of the extension of period of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM20",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM20 - Notice of automatic end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM21",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM21 - Notice of end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM22",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM22 - Notice of a move from administration to creditors' voluntary liquidation",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM23",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM23 - Notice of move from administration to dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM24",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM24 - Notice of a court order in respect of date of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM25",
+      "formCategory": "INSEW2016_ADM"
+    },
+    "formName": "AM25 - Notice of court order ending administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "REC1",
+      "formCategory": "INSEW2016_REC"
+    },
+    "formName": "REC1 - Notice of administrative receiver's report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "REC2",
+      "formCategory": "INSEW2016_REC"
+    },
+    "formName": "REC2 - Notice of summary of receipts and payments",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "REC3",
+      "formCategory": "INSEW2016_REC"
+    },
+    "formName": "REC3 - Notice of order of disposal of charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "REC4",
+      "formCategory": "INSEW2016_REC"
+    },
+    "formName": "REC4 - Notice of statement of affairs in administrative receivership",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "REC5",
+      "formCategory": "INSEW2016_REC"
+    },
+    "formName": "REC5 - Notice of deceased administrative receiver",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RM01",
+      "formCategory": "INSEW2016_REC"
+    },
+    "formName": "RM01 - Notice of appointment of receiver or manager",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RM02",
+      "formCategory": "INSEW2016_REC"
+    },
+    "formName": "RM02 - Notice of ceasing to act as receiver or manager",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ01",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ01 - Notice of statutory declaration of solvency",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ02",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ02 - Notice of statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ03",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ03 - Notice of progress report in voluntary winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ04",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ04 - Notice of order deferring the date of dissolution in MVL or CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ05",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ05 - Notice of order limiting disclosure of statement of affairs in CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ06",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ06 - Notice of liquidator's resignation in MVL or CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ07",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ07 - Notice of removal of liquidator by creditors",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ08",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ08 - Notice of loss of qualification as insolvency practitioner in MVL and CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ09",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ09 - Notice of deceased liquidator in MVL and CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ10",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ10 - Notice of removal of liquidator by court in MVL and CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ11",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ11 - Notice of removal of liquidator by company meeting in MVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ12",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ12 - Notice of release of former liquidator by secretary of state in MVL or CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ13",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ13 - Notice of final account prior to dissolution in MVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "LIQ14",
+      "formCategory": "INSEW2016_VL"
+    },
+    "formName": "LIQ14 - Notice of final account prior to dissolution in CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU01",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU01 - Notice of court order in a winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU02",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU02 - Notice of order of appointment of provisional liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU03",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU03 - Notice of termination of appointment of provisional liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU04",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU04 - Notice of the appointment of liquidator in a winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU07",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU07 - Notice of a progress report in a winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU13",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU13 - Notice of order of court on appeal against decision",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU14",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU14 - Notice of an order for removal of liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "WU15",
+      "formCategory": "INSEW2016_WU"
+    },
+    "formName": "WU15 - Notice of the final account prior to dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "COM1",
+      "formCategory": "INSEW2016_COM"
+    },
+    "formName": "COM1 - Notice of establishment of creditors' or liquidation committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "COM2",
+      "formCategory": "INSEW2016_COM"
+    },
+    "formName": "COM2 - Notice of change of membership of a creditors' or liquidation committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "COM3",
+      "formCategory": "INSEW2016_COM"
+    },
+    "formName": "COM3 - Notice of continuation of creditors' committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "COM4",
+      "formCategory": "INSEW2016_COM"
+    },
+    "formName": "COM4 - Notice of cessation of liquidation committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1
+    ]
+  },
+  {
+    "_id": {
+      "formType": "NOCP",
+      "formCategory": "INSEW2016_EXP"
+    },
+    "formName": "NOCP - Give notice of a court order under section 176A (5) ",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "AM01(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM01 (Scot) - Notice of administrator's appointment",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM02(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM02 (Scot) - Notice of statement of affairs in administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM03(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM03 (Scot) - Notice of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM04(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM04 (Scot) - Notice of the extension of time to deliver administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM05(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM05 (Scot) - Notice of extension of time to seek approval",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM06(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM06 (Scot) - Notice of approval of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM07(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM07 (Scot) - Notice of creditor's decision on administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM08(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM08 (Scot) - Notice of revision of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM09(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM09 (Scot) - Notice of result of a creditor's decision",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM10(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM10 (Scot) - Notice of administrator's progress report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM11(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM11 (Scot) - Appoint a replacement or additional administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM12(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM12 (Scot) - Notice of order limiting disclosure",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM13(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM13 (Scot) - Rescission or amendment of order limiting disclosure",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM14(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM14 (Scot) - Notice of an order to dispose of charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM15(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM15 (Scot) - Resignation of administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM16(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM16 (Scot) - Notice of order removing administrator from office",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM17(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM17 (Scot) - Notice of vacation of office",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM18(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM18 (Scot) - Notice of a deceased administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM19(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM19 (Scot) - Extend the period of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM20(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM20 (Scot) - Notice of automatic end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM21(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM21 (Scot) - Notice of end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM22(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM22 (Scot) - Move a Scottish company from administration to creditors' voluntary liquidation",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM23(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM23 (Scot) - Move a Scottish company from administration to dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM24(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM24 (Scot) - Notice of a court order in respect of date of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AM25(Scot)",
+      "formCategory": "INSSC2018_ADM"
+    },
+    "formName": "AM25 (Scot) - Notice of court order ending administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "COM1(Scot)",
+      "formCategory": "INSSC2018_COM"
+    },
+    "formName": "COM1 (Scot) - Notice of establishment of creditors’ committee (administration)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "COM2(Scot)",
+      "formCategory": "INSSC2018_COM"
+    },
+    "formName": "COM2 (Scot) - Notice of change of membership of a creditors’ committee (administration)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "CVA1(Scot)",
+      "formCategory": "INSSC2018_CVA"
+    },
+    "formName": "CVA1 (Scot) - Notice of voluntary arrangement taking effect",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "CVA2(Scot)",
+      "formCategory": "INSSC2018_CVA"
+    },
+    "formName": "CVA2 (Scot) - Notice of an order of revocation or suspension of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "CVA3(Scot)",
+      "formCategory": "INSSC2018_CVA"
+    },
+    "formName": "CVA3 (Scot) - Notice of a supervisor's progress report in voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "CVA4(Scot)",
+      "formCategory": "INSSC2018_CVA"
+    },
+    "formName": "CVA4 (Scot) - Terminate or fully implement voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM1(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM1 (Scot) - Notice of the commencement of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM2(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM2 (Scot) - Notice of continuation of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM3(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM3 (Scot) - Notice of decision extending or further extending moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM4(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM4 (Scot) - Notice of a court order in relation to a moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM5(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM5 (Scot) - Withdrawal of nominee's consent to act",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM6(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM6 (Scot) - Appoint a replacement nominee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM7(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM7 (Scot) - Notice of the end of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAM8(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAM8 (Scot) - Notice of disposal of charged property during a moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VAMC(Scot)",
+      "formCategory": "INSSC2018_CVAM"
+    },
+    "formName": "VAMC (Scot) - Notice of a court order in respect of a voluntary arrangement or moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "NOCP(Scot)",
+      "formCategory": "INSSC2018_EXP"
+    },
+    "formName": "NOCP (Scot) - Notice of a court order under section 176A(5)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LIQ04(Scot)",
+      "formCategory": "INSSC2018_VL"
+    },
+    "formName": "LIQ04 (Scot) - Notice of order deferring the date of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LIQ13(Scot)",
+      "formCategory": "INSSC2018_VL"
+    },
+    "formName": "LIQ13 (Scot) - Final account prior to dissolution in MVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LIQ14(Scot)",
+      "formCategory": "INSSC2018_VL"
+    },
+    "formName": "LIQ14 (Scot) - Final account prior to dissolution in CVL",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LIQ15(Scot)",
+      "formCategory": "INSSC2018_VL"
+    },
+    "formName": "LIQ15 (Scot) - Notice of a court order staying or sisting proceedings in a CVL or MVL winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "REC1(Scot)",
+      "formCategory": "INSSC2018_REC"
+    },
+    "formName": "REC1 (Scot) - Notice of receiver's report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "REC3(Scot)",
+      "formCategory": "INSSC2018_REC"
+    },
+    "formName": "REC3 (Scot) - Notice of authorisation to dispose of secured property in receivership",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "REC5(Scot)",
+      "formCategory": "INSSC2018_REC"
+    },
+    "formName": "REC5 (Scot) - Notice of a deceased receiver",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "RECSOA(Scot)",
+      "formCategory": "INSSC2018_REC"
+    },
+    "formName": "RECSOA (Scot) - Statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "RM01(Scot)",
+      "formCategory": "INSSC2018_REC"
+    },
+    "formName": "RM01 (Scot) - Notice of appointment of a receiver",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "RM02(Scot)",
+      "formCategory": "INSSC2018_REC"
+    },
+    "formName": "RM02 (Scot) - Notice of ceasing to act as a receiver",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "WU01(Scot)",
+      "formCategory": "INSSC2018_WU"
+    },
+    "formName": "WU01 (Scot) - Notice of a court order in a winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "WU02(Scot)",
+      "formCategory": "INSSC2018_WU"
+    },
+    "formName": "WU02 (Scot) - Notice of order of appointment of a provisional liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "WU03(Scot)",
+      "formCategory": "INSSC2018_WU"
+    },
+    "formName": "WU03 (Scot) - Notice of termination of appointment of provisional liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "WU15(Scot)",
+      "formCategory": "INSSC2018_WU"
+    },
+    "formName": "WU15 (Scot) - Notice of the final account prior to the dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "WU16(Scot)",
+      "formCategory": "INSSC2018_WU"
+    },
+    "formName": "WU16 (Scot) - Early dissolution of a Scottish company in a winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "WU17(Scot)",
+      "formCategory": "INSSC2018_WU"
+    },
+    "formName": "WU17 (Scot) - Defer the dissolution of a Scottish company in a winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "WU18(Scot)",
+      "formCategory": "INSSC2018_WU"
+    },
+    "formName": "WU18 (Scot) - Notice of a court order staying or sisting proceedings in a winding up order by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.1(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.1 - Notice of voluntary arrangement taking effect",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.11(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.11 - Notice of commencement of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.12(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.12 - Notice of extension or continuation of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.14(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.14 - Notice of ending of moratorium",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.16(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.16 - Notice of withdrawal of nominee's consent to act",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.18(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.18 - Notice of the appointment of a replacement nominee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.2(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.2 - Notice of order, revocation or suspension of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.3(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.3 - Notice of supervisor’s abstract of receipts and payments",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "1.4(NI)",
+      "formCategory": "INIO1989_CVAM"
+    },
+    "formName": "1.4 - Notice of completion of voluntary arrangement",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.07(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.07 - Notice of administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.08(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.08 - Administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.12B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.12B - Notice of administrator's appointment",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.14B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.14B - Statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.15B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.15B - Statement of concurrence",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.16(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.16 - Administrator's abstracts",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.16B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.16B - Notice of statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.17B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.17B - Statement of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.18B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.18B - Notice of extension of time period",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.18BA(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.18BA - Notice of deemed approval of proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.19(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.19 - Notice of order to deal with charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.20(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.20 - Notice of discharge of administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.21(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.21 - Notice of variation of administration order",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.22(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.22 - Statement of administrator's proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.22B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.22B - Statement of administrator's revised proposals",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.23B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.23B - Notice of result of creditors’ meeting",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.24(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.24 - Notice of result of meeting of creditors",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.24B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.24B - Notice of administrator’s progress report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.26B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.26B - Amend certificate of constitution of creditors’ committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.27B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.27B - Notice by administrator of a change in committee membership",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.28B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.28B - Notice of order to deal with charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.30B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.30B - Notice of automatic end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.31B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.31B - Notice of the extension period of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.32B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.32B - Notice of end of administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.33B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.33B - Notice of court order ending administration",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.34B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.34B - Notice of move from administration to creditors’ voluntary liquidation",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.35B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.35B - Notice of move from administration to dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.36B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.36B - Notice to registrar of companies in respect of date of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.38B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.38B - Notice of resignation by administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.39B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.39B - Notice of vacation of office by administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.4(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.4 - Notice of appointment of replacement/additional administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "2.40B(NI)",
+      "formCategory": "INIO1989_ADM"
+    },
+    "formName": "2.40B - Notice of appointment of replacement/additional administrator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.04(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.04 - Statement of affairs receivership",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.05(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.05 - Statement of affairs in administrative receivership following report to creditors",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.06(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.06 - Certificate of constitution (amended certificate) of creditors' committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.07(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.07 - Administrative receiver's report as to change in membership of creditors' committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.08(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.08 - Receiver or manager or administrative receiver's abstract of receipts and payment",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.09(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.09 - Notice of administrative receiver's death",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.10(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.10 - Notice of order to dispose of charged property",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3.12(NI)",
+      "formCategory": "INIO1989_REC"
+    },
+    "formName": "3.12 - Administrative receiver's report",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LRESC(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "Creditors' voluntary liquidation resolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LRESM(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "Members' voluntary liquidation resolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "L21(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "L21 - Early completion of winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "L22(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "L22 - Completion of winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "L131(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "L131 - Deferment of dissolution (compulsory)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "VL1",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "VL1 - Notice of appointment of liquidator: voluntary winding up (members or creditors)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.16(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.16 - Notice of appointment of provisional liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.16A(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.16A - Notice of appointment of provisional liquidator in winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.19(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.19 - Statement of affairs: voluntary liquidation",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.21(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.21 - Statement of affairs",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.23(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.23 - Deferment of dissolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.26(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.26 - Proof of debt",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.32(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.32 - Notice of appointment of a liquidator in winding up by the court",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.34(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.34 - Notice of resignation as voluntary liquidator under Article 145(5) of the Insolvency (Northern Ireland) Order 1989",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.36(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.36 - Notice of order of court granting liquidator leave to resign",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.39(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.39 - Certificate of removal of voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.41(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.41 - Notice of ceasing to act as voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.44(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.44 - Notice of final meeting of creditors",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.45(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.45 - Notice of death of voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.47(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.47 - Notice of vacation of office by voluntary liquidator",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.52(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.52 - Certificate that creditors have been paid in full",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.53(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.53 - Liquidator's certificate of continuance of liquidation committee",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.69(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.69 - Liquidator's statement of receipts and payments",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.70(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.70 - Order of court on appeal against secretary of state's decision",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.71(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.71 - Declaration of solvency",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.72(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.72 - Return of final meeting in a members' voluntary winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "4.73(NI)",
+      "formCategory": "INIO1989_LIQ"
+    },
+    "formName": "4.73 - Return of final meeting in a creditors' voluntary winding up",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "OSDS02",
+      "formCategory": "OCR2009"
+    },
+    "formName": "OS DS02 - Termination of overseas company insolvency proceedings",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "OSLQ01",
+      "formCategory": "OCR2009"
+    },
+    "formName": "OS LQ01 - Appointment of liquidator of overseas company",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "OSLQ02",
+      "formCategory": "OCR2009"
+    },
+    "formName": "OS LQ02 - Insolvency proceedings against overseas company",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "OSLQ03",
+      "formCategory": "OCR2009"
+    },
+    "formName": "OS LQ03 - Notice of winding up of an overseas company",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "OSLQ04",
+      "formCategory": "OCR2009"
+    },
+    "formName": "OS LQ04 - Cessation of overseas company subject to insolvency proceedings",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LLRM01",
+      "formCategory": "LLPR2009"
+    },
+    "formName": "LL RM01 - Notice of appointment of an administrative receiver, receiver or manager",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LLRM02",
+      "formCategory": "LLPR2009"
+    },
+    "formName": "LL RM02 - Notice of ceasing to act as an administrative receiver, receiver or manager",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LRESEX",
+      "formCategory": "INS_RES"
+    },
+    "formName": "Extraordinary resolution to wind up (creditors' voluntary liquidation)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "LRESSP",
+      "formCategory": "INS_RES"
+    },
+    "formName": "Special resolution to wind up (members' voluntary liquidation)",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "3(Scot)",
+      "formCategory": "IA1986_REC"
+    },
+    "formName": "Form 3 (Scotland) - Cease to act as administrative receiver, receiver or manager",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": null
+  },
+  {
+    "_id": {
+      "formType": "AD01",
+      "formCategory": "INSCROA"
+    },
+    "formName": "AD01 – Change a company’s registered office address",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "RESOLUTIONS",
+      "formCategory": "SH"
+    },
+    "formName": "Resolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH02",
+      "formCategory": "SH"
+    },
+    "formName": "SH02 - Consolidate, sub-divide, redeem shares or re-convert stock into shares",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH04",
+      "formCategory": "SH"
+    },
+    "formName": "SH04 - Notify a sale or transfer of treasury shares",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH05",
+      "formCategory": "SH"
+    },
+    "formName": "SH05 - Notify a cancellation of treasury shares",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH06",
+      "formCategory": "SH"
+    },
+    "formName": "SH06 - Notify a cancellation of shares",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4,
+      5
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH07",
+      "formCategory": "SH"
+    },
+    "formName": "SH07 - Notify a cancellation of shares held by or for a public company",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH08",
+      "formCategory": "SH"
+    },
+    "formName": "SH08 - Notify a name or other designation of class of shares",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH09",
+      "formCategory": "SH"
+    },
+    "formName": "SH09 - Allotting a new class of shares by an unlimited company",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH10",
+      "formCategory": "SH"
+    },
+    "formName": "SH10 - Give notice of particulars of variation of rights attached to shares",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH11",
+      "formCategory": "SH"
+    },
+    "formName": "SH11 - Give notice of a new class of members",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH12",
+      "formCategory": "SH"
+    },
+    "formName": "SH12 - Give notice of particulars of variation of class rights",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH13",
+      "formCategory": "SH"
+    },
+    "formName": "SH13 - Give notice of name or other designation of class of members",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH14",
+      "formCategory": "SH"
+    },
+    "formName": "SH14 - Notify a redenomination of shares",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH15",
+      "formCategory": "SH"
+    },
+    "formName": "SH15 - Notify a reduction of capital following redenomination",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH16",
+      "formCategory": "SH"
+    },
+    "formName": "SH16 - Give notice of application to court to cancel special resolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  },
+  {
+    "_id": {
+      "formType": "SH17",
+      "formCategory": "SH"
+    },
+    "formName": "SH17 - Give notice by the company of application to cancel special resolution",
+    "fee": "",
+    "isAuthenticationRequired": true,
+    "isFesEnabled": true,
+    "messageTextIdList": [
+      1,
+      4
+    ]
+  }
+]

--- a/src/test/java/uk/gov/companieshouse/efs/api/companyauthallowlist/service/CompanyAuthAllowListServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/companyauthallowlist/service/CompanyAuthAllowListServiceImplTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.efs.api.companyauthallowlist.repository.CompanyAuthAllowListRepository;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/InternalSubmissionEmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/InternalSubmissionEmailMapperTest.java
@@ -24,7 +24,6 @@ import uk.gov.companieshouse.efs.api.email.model.EmailDocument;
 import uk.gov.companieshouse.efs.api.email.model.EmailFileDetails;
 import uk.gov.companieshouse.efs.api.email.model.InternalSubmissionEmailData;
 import uk.gov.companieshouse.efs.api.email.model.InternalSubmissionEmailModel;
-import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.efs.api.submissions.model.Company;
 import uk.gov.companieshouse.efs.api.submissions.model.FileDetails;

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
@@ -12,15 +12,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-
 import uk.gov.companieshouse.api.model.efs.submissions.FileConversionStatus;
 import uk.gov.companieshouse.efs.api.events.service.model.Decision;
 import uk.gov.companieshouse.efs.api.events.service.model.DecisionResult;
@@ -135,7 +132,8 @@ class DecisionEngineTest {
                 .withFormType("AD01")
                 .build());
         when(timestampGenerator.generateTimestamp()).thenReturn(now);
-        when(formTemplateRepository.findById(anyString())).thenReturn(Optional.of(new FormTemplate("AD01", "Change of address", "CC", "", false, true, null)));
+        when(formTemplateRepository.findByIdFormType(anyString())).thenReturn(Collections.singletonList(
+            new FormTemplate(new FormTemplate.FormTypeKey("AD01", ""), "Change of address", "", false, true, null)));
 
         //when
         Map<DecisionResult, List<Decision>> actual = decisionEngine
@@ -148,7 +146,7 @@ class DecisionEngineTest {
         verify(timestampGenerator).generateTimestamp();
         verify(apiClient).details("abc");
         verify(submissionService).updateSubmission(submission);
-        verify(formTemplateRepository).findById(eq("AD01"));
+        verify(formTemplateRepository).findByIdFormType(eq("AD01"));
     }
 
     @Test
@@ -162,7 +160,8 @@ class DecisionEngineTest {
                 .withFormType("AD01")
                 .build());
         when(timestampGenerator.generateTimestamp()).thenReturn(now);
-        when(formTemplateRepository.findById(anyString())).thenReturn(Optional.of(new FormTemplate("AD01", "Change of address", "CC", "", false, false, null)));
+        when(formTemplateRepository.findByIdFormType(anyString())).thenReturn(Collections.singletonList(
+            new FormTemplate(new FormTemplate.FormTypeKey("AD01", ""), "Change of address", "", false, false, null)));
 
         //when
         Map<DecisionResult, List<Decision>> actual = decisionEngine
@@ -175,7 +174,7 @@ class DecisionEngineTest {
         verify(timestampGenerator).generateTimestamp();
         verify(apiClient).details("abc");
         verify(submissionService).updateSubmission(submission);
-        verify(formTemplateRepository).findById(eq("AD01"));
+        verify(formTemplateRepository).findByIdFormType(eq("AD01"));
     }
 
     @Test
@@ -189,7 +188,7 @@ class DecisionEngineTest {
                 .withFormType("AD01")
                 .build());
         when(timestampGenerator.generateTimestamp()).thenReturn(now);
-        when(formTemplateRepository.findById(anyString())).thenReturn(Optional.empty());
+        when(formTemplateRepository.findByIdFormType(anyString())).thenReturn(Collections.emptyList());
 
         //when
         Map<DecisionResult, List<Decision>> actual = decisionEngine
@@ -202,7 +201,7 @@ class DecisionEngineTest {
         verify(timestampGenerator).generateTimestamp();
         verify(apiClient).details("abc");
         verify(submissionService).updateSubmission(submission);
-        verify(formTemplateRepository).findById(eq("AD01"));
+        verify(formTemplateRepository).findByIdFormType(eq("AD01"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
@@ -133,7 +133,7 @@ class DecisionEngineTest {
                 .build());
         when(timestampGenerator.generateTimestamp()).thenReturn(now);
         when(formTemplateRepository.findByIdFormType(anyString())).thenReturn(Collections.singletonList(
-            new FormTemplate(new FormTemplate.FormTypeKey("AD01", ""), "Change of address", "", false, true, null)));
+            new FormTemplate(new FormTemplate.FormTypeId("AD01", ""), "Change of address", "", false, true, null)));
 
         //when
         Map<DecisionResult, List<Decision>> actual = decisionEngine
@@ -161,7 +161,7 @@ class DecisionEngineTest {
                 .build());
         when(timestampGenerator.generateTimestamp()).thenReturn(now);
         when(formTemplateRepository.findByIdFormType(anyString())).thenReturn(Collections.singletonList(
-            new FormTemplate(new FormTemplate.FormTypeKey("AD01", ""), "Change of address", "", false, false, null)));
+            new FormTemplate(new FormTemplate.FormTypeId("AD01", ""), "Change of address", "", false, false, null)));
 
         //when
         Map<DecisionResult, List<Decision>> actual = decisionEngine

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateControllerTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.logging.Logger;
 
 @ExtendWith(MockitoExtension.class)
-class FormTemplateTemplateControllerTest {
+class FormTemplateControllerTest {
 
     @Mock
     private FormTemplateService service;
@@ -80,10 +80,11 @@ class FormTemplateTemplateControllerTest {
     }
 
     @Test
-    void testGetFormsTemplate() {
+    void testGetFormTemplate() {
         //given
         FormTemplateApi expected = new FormTemplateApi();
         final String formType = "form01";
+        
         when(service.getFormTemplate(formType)).thenReturn(expected);
 
         //when
@@ -99,6 +100,7 @@ class FormTemplateTemplateControllerTest {
 
         //given
         final String formType = "form01";
+        
         when(service.getFormTemplate(formType)).thenThrow(new RuntimeException("Test exception scenario"));
 
         //when

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapperTest.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.model.efs.formtemplates.MessageTextListApi;
 import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 
 class FormTemplateMapperTest {
+    private static final FormTemplate.FormTypeKey FORM_TYPE_KEY = new FormTemplate.FormTypeKey("IN01", "NEWINC");
     private FormTemplateMapper mapper;
 
     @BeforeEach
@@ -70,7 +71,7 @@ class FormTemplateMapperTest {
     }
 
     private FormTemplate getForm(final List<Integer> messageTextIdList) {
-        return new FormTemplate("IN01", "New Incorporation", "NEWINC", "12",
+        return new FormTemplate(FORM_TYPE_KEY, "New Incorporation", "12",
                 false, false, messageTextIdList);
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapperTest.java
@@ -13,7 +13,7 @@ import uk.gov.companieshouse.api.model.efs.formtemplates.MessageTextListApi;
 import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 
 class FormTemplateMapperTest {
-    private static final FormTemplate.FormTypeKey FORM_TYPE_KEY = new FormTemplate.FormTypeKey("IN01", "NEWINC");
+    private static final FormTemplate.FormTypeId FORM_TYPE_KEY = new FormTemplate.FormTypeId("IN01", "NEWINC");
     private FormTemplateMapper mapper;
 
     @BeforeEach

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.Matchers;
@@ -15,22 +17,26 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 class FormTemplateTest {
-
+    private static final FormTemplate.FormTypeKey FORM_TYPE_KEY = new FormTemplate.FormTypeKey("CC01", "CC");
+    public static final List<Integer> MESSAGE_TEXT_ID_LIST = Collections.singletonList(1);
+    
     private FormTemplate testFormTemplate;
 
     @BeforeEach
     void setUp() {
-        testFormTemplate = new FormTemplate("CC01", "Form01", "CC", "100", false, false, null);
+        testFormTemplate = new FormTemplate(FORM_TYPE_KEY, "Form01", "100", false, false, null);
+        testFormTemplate.setMessageTextIdList(MESSAGE_TEXT_ID_LIST);
         JacksonTester.initFields(this, new ObjectMapper());
     }
 
     @Test
     void formTemplate() {
-
+        assertThat(testFormTemplate.getId(), is(FORM_TYPE_KEY));
         assertThat(testFormTemplate.getFormType(), is("CC01"));
-        assertThat(testFormTemplate.getFormName(), is("Form01"));
         assertThat(testFormTemplate.getFormCategory(), is("CC"));
+        assertThat(testFormTemplate.getFormName(), is("Form01"));
         assertThat(testFormTemplate.getFee(), is("100"));
+        assertThat(testFormTemplate.getMessageTextIdList(), is(MESSAGE_TEXT_ID_LIST));
     }
 
     @Test
@@ -43,8 +49,8 @@ class FormTemplateTest {
     void toStringTest() {
         assertThat(testFormTemplate.toString(), Matchers.is(
                 //@formatter:off
-                "FormTemplate[formType=CC01,formName=Form01,formCategory=CC,fee=100," +
-                        "isAuthenticationRequired=false,isFesEnabled=false,messageTextIdList=<null>]"
+                "FormTemplate[formType=CC01,formCategory=CC,formName=Form01,fee=100," +
+                        "isAuthenticationRequired=false,isFesEnabled=false,messageTextIdList=[1]]"
                 //@formatter:on
         ));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 class FormTemplateTest {
-    private static final FormTemplate.FormTypeKey FORM_TYPE_KEY = new FormTemplate.FormTypeKey("CC01", "CC");
+    private static final FormTemplate.FormTypeId FORM_TYPE_KEY = new FormTemplate.FormTypeId("CC01", "CC");
     public static final List<Integer> MESSAGE_TEXT_ID_LIST = Collections.singletonList(1);
     
     private FormTemplate testFormTemplate;

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTypeIdTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTypeIdTest.java
@@ -13,22 +13,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class FormTypeKeyTest {
-    private FormTemplate.FormTypeKey testKey;
+class FormTypeIdTest {
+    private FormTemplate.FormTypeId testKey;
 
     @BeforeEach
     void setUp() {
-        testKey = new FormTemplate.FormTypeKey("form", "category");
+        testKey = new FormTemplate.FormTypeId("form", "category");
     }
     
     @Test
     void isSerializable() {
-        assertThat(new FormTemplate.FormTypeKey(), isA(Serializable.class));    
+        assertThat(new FormTemplate.FormTypeId(), isA(Serializable.class));    
     }
     
     @Test
     void equalsAndHashCode() {
-        EqualsVerifier.forClass(FormTemplate.FormTypeKey.class).usingGetClass().verify();
+        EqualsVerifier.forClass(FormTemplate.FormTypeId.class).usingGetClass().verify();
     }
     
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTypeKeyTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTypeKeyTest.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.efs.api.formtemplates.model;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.isA;
+
+import java.io.Serializable;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FormTypeKeyTest {
+    private FormTemplate.FormTypeKey testKey;
+
+    @BeforeEach
+    void setUp() {
+        testKey = new FormTemplate.FormTypeKey("form", "category");
+    }
+    
+    @Test
+    void isSerializable() {
+        assertThat(new FormTemplate.FormTypeKey(), isA(Serializable.class));    
+    }
+    
+    @Test
+    void equalsAndHashCode() {
+        EqualsVerifier.forClass(FormTemplate.FormTypeKey.class).usingGetClass().verify();
+    }
+    
+    @Test
+    void getFormType() {
+        assertThat(testKey.getFormType(), is("form"));
+    }
+
+    @Test
+    void getFormCategory() {
+        assertThat(testKey.getFormCategory(), is("category"));
+    }
+
+    @Test
+    void testToString() {
+        assertThat(testKey.toString(), containsString("formType=form"));
+        assertThat(testKey.toString(), containsString("formCategory=category"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
@@ -38,6 +38,13 @@ class FormTemplateServiceImplTest {
     private FormTemplate formTemplate;
 
     private FormTemplateServiceImpl service;
+    public static final String FORM_TYPE = "IN01";
+    public static final String CATEGORY_TYPE = "NEWINC";
+    public static final FormTemplate.FormTypeKey FORM_TYPE_KEY = new FormTemplate.FormTypeKey(FORM_TYPE, CATEGORY_TYPE);
+    public static final FormTemplateApi FORM_TEMPLATE =
+        new FormTemplateApi(FORM_TYPE, "New Incorporation", CATEGORY_TYPE, "12", false, false, null);
+    public static final FormTemplate MAPPED_FORM =
+        new FormTemplate(FORM_TYPE_KEY, "New Incorporation", "12", false, false, null);
 
     @BeforeEach
     void setUp() {
@@ -72,17 +79,17 @@ class FormTemplateServiceImplTest {
     void testFetchEntityAndMapToFormTemplateApiObject() {
 
         //given
-        String categoryId = "CC01";
-        FormTemplate formTemplate = new FormTemplate("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, null);
-        FormTemplateApi mappedForm = new FormTemplateApi("IN01", "New Incorporation", "NEWINC", "12",
+        final FormTemplate.FormTypeKey formTypeKey = new FormTemplate.FormTypeKey(FORM_TYPE, CATEGORY_TYPE);
+        FormTemplate formTemplate = new FormTemplate(formTypeKey, "New Incorporation", "12", false, false, null);
+        FormTemplateApi mappedForm =
+            new FormTemplateApi(formTypeKey.getFormType(), "New Incorporation", formTypeKey.getFormCategory(), "12",
                 false, false, null);
 
-        when(formRepository.findById(categoryId)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findById(FORM_TYPE_KEY)).thenReturn(Optional.of(formTemplate));
         when(mapper.map(formTemplate)).thenReturn(mappedForm);
 
         //when
-        FormTemplateApi actual = service.getFormTemplate(categoryId);
+        FormTemplateApi actual = service.getFormTemplateById(FORM_TYPE_KEY);
 
         //then
         assertEquals(mappedForm, actual);
@@ -92,11 +99,9 @@ class FormTemplateServiceImplTest {
     void testFetchEntityWhenFormTemplateApiObjectNotFound() {
 
         //given
-        String categoryId = "CC01";
-
-        when(formRepository.findById(categoryId)).thenReturn(Optional.empty());
+        when(formRepository.findById(FORM_TYPE_KEY)).thenReturn(Optional.empty());
         //when
-        FormTemplateApi actual = service.getFormTemplate(categoryId);
+        FormTemplateApi actual = service.getFormTemplateById(FORM_TYPE_KEY);
 
         //then
         assertThat(actual, is(nullValue()));
@@ -108,13 +113,11 @@ class FormTemplateServiceImplTest {
 
         //given
         String categoryId = "CC01";
-        FormTemplate mappedForm = new FormTemplate("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, null);
 
         List<FormTemplate> listForm = new ArrayList<>();
-        listForm.add(mappedForm);
+        listForm.add(MAPPED_FORM);
 
-        when(formRepository.findByFormCategory(categoryId)).thenReturn(listForm);
+        when(formRepository.findByIdFormCategory(categoryId)).thenReturn(listForm);
         when(mapper.map(anyList())).thenReturn(formList);
 
         //when
@@ -123,4 +126,36 @@ class FormTemplateServiceImplTest {
         //then
         assertEquals(formList, actual);
     }
+
+    @Test
+    void fetchEntityAndMapToFormTemplateApiObjectByFormType() {
+        List<FormTemplate> listForm = new ArrayList<>();
+        listForm.add(MAPPED_FORM);
+
+        //given
+        when(formRepository.findByIdFormType(FORM_TYPE)).thenReturn(listForm);
+        when(mapper.map(listForm.get(0))).thenReturn(FORM_TEMPLATE);
+
+        //when
+        FormTemplateApi actual = service.getFormTemplate(FORM_TYPE);
+
+        //then
+        assertThat(actual, is(FORM_TEMPLATE));
+    }
+
+    @Test
+    void fetchEntityAndMapToFormTemplateApiObjectNotFound() {
+        List<FormTemplate> listForm = new ArrayList<>();
+
+        //given
+        when(formRepository.findByIdFormType(FORM_TYPE)).thenReturn(listForm);
+
+        //when
+        FormTemplateApi actual = service.getFormTemplate(FORM_TYPE);
+
+        //then
+        assertThat(actual, is(nullValue()));
+        verifyNoInteractions(mapper);
+    }
+
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
@@ -40,7 +40,7 @@ class FormTemplateServiceImplTest {
     private FormTemplateServiceImpl service;
     public static final String FORM_TYPE = "IN01";
     public static final String CATEGORY_TYPE = "NEWINC";
-    public static final FormTemplate.FormTypeKey FORM_TYPE_KEY = new FormTemplate.FormTypeKey(FORM_TYPE, CATEGORY_TYPE);
+    public static final FormTemplate.FormTypeId FORM_TYPE_KEY = new FormTemplate.FormTypeId(FORM_TYPE, CATEGORY_TYPE);
     public static final FormTemplateApi FORM_TEMPLATE =
         new FormTemplateApi(FORM_TYPE, "New Incorporation", CATEGORY_TYPE, "12", false, false, null);
     public static final FormTemplate MAPPED_FORM =
@@ -79,10 +79,10 @@ class FormTemplateServiceImplTest {
     void testFetchEntityAndMapToFormTemplateApiObject() {
 
         //given
-        final FormTemplate.FormTypeKey formTypeKey = new FormTemplate.FormTypeKey(FORM_TYPE, CATEGORY_TYPE);
-        FormTemplate formTemplate = new FormTemplate(formTypeKey, "New Incorporation", "12", false, false, null);
+        final FormTemplate.FormTypeId formTypeId = new FormTemplate.FormTypeId(FORM_TYPE, CATEGORY_TYPE);
+        FormTemplate formTemplate = new FormTemplate(formTypeId, "New Incorporation", "12", false, false, null);
         FormTemplateApi mappedForm =
-            new FormTemplateApi(formTypeKey.getFormType(), "New Incorporation", formTypeKey.getFormCategory(), "12",
+            new FormTemplateApi(formTypeId.getFormType(), "New Incorporation", formTypeId.getFormCategory(), "12",
                 false, false, null);
 
         when(formRepository.findById(FORM_TYPE_KEY)).thenReturn(Optional.of(formTemplate));

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceTest.java
@@ -1,11 +1,12 @@
 package uk.gov.companieshouse.efs.api.formtemplates.service;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 
 class FormTemplateServiceTest {
 
@@ -30,16 +31,28 @@ class FormTemplateServiceTest {
 
     @Test
     void getFormTemplate() {
+        final FormTemplate.FormTypeKey formTypeKey = new FormTemplate.FormTypeKey("RESOLUTIONS", "CC");
+        
         UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
-                () -> testService.getFormTemplate("CC01"));
+            () -> {
+                testService.getFormTemplateById(formTypeKey);
+            });
+
+        assertThat(thrown.getMessage(), is("not implemented"));
+    }
+
+    @Test
+    void getFormTemplateByFormType() {
+        UnsupportedOperationException thrown =
+            assertThrows(UnsupportedOperationException.class, () -> testService.getFormTemplate("CC01"));
 
         assertThat(thrown.getMessage(), is("not implemented"));
     }
 
     @Test
     void getFormTemplatesByCategory() {
-        UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
-                () -> testService.getFormTemplatesByCategory("CC01"));
+        UnsupportedOperationException thrown =
+            assertThrows(UnsupportedOperationException.class, () -> testService.getFormTemplatesByCategory("CC01"));
 
         assertThat(thrown.getMessage(), is("not implemented"));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceTest.java
@@ -31,11 +31,11 @@ class FormTemplateServiceTest {
 
     @Test
     void getFormTemplate() {
-        final FormTemplate.FormTypeKey formTypeKey = new FormTemplate.FormTypeKey("RESOLUTIONS", "CC");
+        final FormTemplate.FormTypeId formTypeId = new FormTemplate.FormTypeId("RESOLUTIONS", "CC");
         
         UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
             () -> {
-                testService.getFormTemplateById(formTypeKey);
+                testService.getFormTemplateById(formTypeId);
             });
 
         assertThat(thrown.getMessage(), is("not implemented"));

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/ConfirmAuthorisedValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/ConfirmAuthorisedValidatorTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.text.MessageFormat;
-import java.util.Optional;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -48,7 +48,7 @@ class ConfirmAuthorisedValidatorTest {
         testValidator.setNext(nextValidator);
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn(TEST_FORM);
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
 
         testValidator.validate(submission);
 
@@ -61,7 +61,7 @@ class ConfirmAuthorisedValidatorTest {
         testValidator.setNext(nextValidator);
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn(TEST_FORM);
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
         when(formTemplate.getFormCategory()).thenReturn("ANY BUT INSOLVENCY");
         when(categoryService.getTopLevelCategory(anyString())).thenReturn(CategoryTypeConstants.OTHER);
 
@@ -79,7 +79,7 @@ class ConfirmAuthorisedValidatorTest {
         when(formDetails.getFormType()).thenReturn(TEST_FORM);
         when(formTemplate.getFormType()).thenReturn(TEST_FORM);
         when(formTemplate.getFormCategory()).thenReturn(CategoryTypeConstants.INSOLVENCY.getValue());
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
         when(categoryService.getTopLevelCategory(anyString())).thenReturn(CategoryTypeConstants.INSOLVENCY);
 
         final SubmissionValidationException exception =
@@ -99,7 +99,7 @@ class ConfirmAuthorisedValidatorTest {
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn(TEST_FORM);
         when(formTemplate.getFormCategory()).thenReturn("ANY BUT INSOLVENCY");
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
         when(categoryService.getTopLevelCategory(anyString())).thenReturn(CategoryTypeConstants.OTHER);
 
         testValidator.validate(submission);
@@ -115,7 +115,7 @@ class ConfirmAuthorisedValidatorTest {
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn(TEST_FORM);
         when(formTemplate.getFormCategory()).thenReturn("ANY BUT INSOLVENCY");
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
         when(categoryService.getTopLevelCategory(anyString())).thenReturn(CategoryTypeConstants.OTHER);
 
         testValidator.validate(submission);
@@ -131,7 +131,7 @@ class ConfirmAuthorisedValidatorTest {
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn(TEST_FORM);
         when(formTemplate.getFormCategory()).thenReturn("INS");
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
         when(categoryService.getTopLevelCategory(anyString())).thenReturn(CategoryTypeConstants.INSOLVENCY);
 
         testValidator.validate(submission);

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/FesAttachmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/FesAttachmentValidatorTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import java.text.MessageFormat;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.BooleanUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,8 +106,8 @@ class FesAttachmentValidatorTest {
         final String formType = BooleanUtils.isTrue(hasFee) ? FEE_FORM : NO_FEE_FORM;
 
         when(formDetails.getFormType()).thenReturn(formType);
-        when(formRepository.findById(formType))
-            .thenReturn(hasFee != null ? Optional.of(formTemplate) : Optional.empty());
+        when(formRepository.findByIdFormType(formType))
+            .thenReturn(hasFee != null ? Collections.singletonList(formTemplate) : Collections.emptyList());
         if (fesEnabled != null) {
             when(formTemplate.isFesEnabled()).thenReturn(fesEnabled);
         }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/FormTemplateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/FormTemplateValidatorTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.text.MessageFormat;
-import java.util.Optional;
+import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,8 +56,8 @@ class FormTemplateValidatorTest {
     void validateWhenFormFoundThenValid() throws SubmissionValidationException {
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn("FORM");
-        when(formRepository.findById("FORM")).thenReturn(Optional.of(
-            new FormTemplate(null, null, null, null, false, false, null)));
+        when(formRepository.findByIdFormType("FORM")).thenReturn(
+            Collections.singletonList(new FormTemplate(null, null, null, false, false, null)));
 
         testValidator.validate(submission);
 
@@ -69,7 +69,7 @@ class FormTemplateValidatorTest {
         when(submission.getId()).thenReturn(SUB_ID);
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn("FORM");
-        when(formRepository.findById("FORM")).thenReturn(Optional.empty());
+        when(formRepository.findByIdFormType("FORM")).thenReturn(Collections.emptyList());
 
         final SubmissionValidationException exception =
             assertThrows(SubmissionValidationException.class, () -> testValidator.validate(submission));

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/PaymentSessionsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/PaymentSessionsValidatorTest.java
@@ -81,7 +81,7 @@ class PaymentSessionsValidatorTest {
     @Test
     void validateWhenFormNotFoundThenValid() throws SubmissionValidationException {
         expectSubmissionWithForm();
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.empty());
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.emptyList());
 
         testValidator.validate(submission);
 
@@ -175,7 +175,7 @@ class PaymentSessionsValidatorTest {
     @Test
     void validateWhenFeeAmountZeroThenValid() throws SubmissionValidationException {
         expectSubmissionWithForm();
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
         when(formTemplate.getFee()).thenReturn(TEST_FEE);
         expectPaymentTemplateWithSingleItem();
         when(paymentItem.getAmount()).thenReturn("0.00");
@@ -246,7 +246,7 @@ class PaymentSessionsValidatorTest {
     }
 
     private void expectFormWithPaymentTemplate(final String paymentTemplateId) {
-        when(formRepository.findById(TEST_FORM)).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(TEST_FORM)).thenReturn(Collections.singletonList(formTemplate));
         when(formTemplate.getFormType()).thenReturn(TEST_FORM);
         when(formTemplate.getFee()).thenReturn(paymentTemplateId);
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/SubmissionValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/SubmissionValidatorTest.java
@@ -70,7 +70,7 @@ class SubmissionValidatorTest {
         when(submission.getCompany()).thenReturn(new Company("00001234", "ACME"));
         when(submission.getFormDetails())
             .thenReturn(new FormDetails(null, NON_FEE_FORM, Collections.singletonList(FileDetails.builder().build())));
-        when(formRepository.findById(anyString())).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(anyString())).thenReturn(Collections.singletonList(formTemplate));
         when(formTemplate.getFee()).thenReturn(null);
         when(formTemplate.getFormCategory()).thenReturn("SH");
         when(formTemplate.getFormType()).thenReturn(NON_FEE_FORM);
@@ -88,7 +88,7 @@ class SubmissionValidatorTest {
         when(submission.getCompany()).thenReturn(new Company("00001234", "ACME"));
         when(submission.getFormDetails())
             .thenReturn(new FormDetails(null, FEE_FORM, Collections.singletonList(FileDetails.builder().build())));
-        when(formRepository.findById(anyString())).thenReturn(Optional.of(formTemplate));
+        when(formRepository.findByIdFormType(anyString())).thenReturn(Collections.singletonList(formTemplate));
         when(formTemplate.getFee()).thenReturn("TEST_FEE");
         when(paymentRepository.findById("TEST_FEE")).thenReturn(Optional.of(paymentTemplate));
         when(paymentTemplate.getItems()).thenReturn(Collections.singletonList(TEST_ITEM));


### PR DESCRIPTION
Background: The same Form type (as identified in FES/CHIPS) is required to be listed in multiple categories within EFS.
e.g. "RESOLUTIONS" form type is should to be listed in both "CC" and "SH" form categories.
There is currently a primary key (unique) constraint on the form_templates data forbidding this.

Changes to replace the `_id` primary key datatype from `formType` (String) to composite class `FormTypeId` consisting of `formType` and `categoryType` values.

Assumes that multiple documents in the `form_templates` collections are identical, i.e. have the same properties except for `id.categoryType`.
e.g. `GET /form-templates?type=RESOLUTIONS` will return the first one in the collection with id.formType == "RESOLUTIONS".
#### Note
`form_templates.json` data has been refactored to use the composite primary key.

