### PR TITLE
fix for BI-8212 Spec Cap res is 'S CAP RES' on FES and CHIPS

### DIFF
--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -2909,7 +2909,7 @@
   "isFesEnabled" : true,
   "messageTextIdList": [1,4]
 }, {
-  "_id" : "S-CAP-RES",
+  "_id" : "S CAP RES",
   "formName" : "Resolution - Approving a share capital reduction",
   "formCategory" : "SH-RED",
   "fee" : "",


### PR DESCRIPTION
see the sql we've done in BI-6252 and BI-6256.

Have confirmed with Leon that no hyphens should be used.

BI-8212