### PR TITLE
Support FES same day indicator for form templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>2.0.71</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.72</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -1327,25 +1327,20 @@
           "example": "10.00",
           "description": "Form fee"
         },
-        "isAuthenticationRequired": {
+        "authenticationRequired": {
           "type": "boolean",
           "example": "false",
           "description": "Is authentication required?"
         },
-        "isInternalEmailRequired": {
-          "type": "boolean",
-          "example": "false",
-          "description": "Is internal email required?"
-        },
-        "isFesEnabled": {
+        "fes_enabled": {
           "type": "boolean",
           "example": "false",
           "description": "FES enabled?"
         },
-        "isSameDayService": {
+        "same_day": {
           "type": "boolean",
           "example": false,
-          "description": "Is same day service required?"
+          "description": "Is same day indicator required?"
         }
       }
     },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Emergency Filing Service API",
     "description": "Emergency Filing Service API specification",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "basePath": "/efs-submissions-api",
   "schemes": [
@@ -94,8 +94,8 @@
       "x-example": "Insolvency"
     },
     "template-id": {
-      "name": "template-id",
-      "in": "path",
+      "name": "type",
+      "in": "query",
       "description": "Unique form template selector",
       "required": true,
       "type": "string",
@@ -637,7 +637,7 @@
         }
       }
     },
-    "/form-template/{template-id}": {
+    "/form-template": {
       "parameters": [
         {
           "$ref": "#/parameters/template-id"
@@ -1341,6 +1341,11 @@
           "type": "boolean",
           "example": "false",
           "description": "FES enabled?"
+        },
+        "isSameDayService": {
+          "type": "boolean",
+          "example": false,
+          "description": "Is same day service required?"
         }
       }
     },

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/EventServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/EventServiceImpl.java
@@ -199,10 +199,13 @@ public class EventServiceImpl implements EventService {
 
                 // insert into FES DB
 
-                fesLoaderService.insertSubmission(new FesLoaderModel(barcode, submission.getCompany().getCompanyName(),
-                    submission.getCompany().getCompanyNumber(), fesDocType, tiffFiles, submittedAt));
-                LOGGER.debug(String.format("Inserted submission details into FES DB for submission [%s], form [%s]",
-                        submission.getId(), fesDocType));
+                fesLoaderService.insertSubmission(
+                    new FesLoaderModel(barcode, submission.getCompany().getCompanyName(),
+                        submission.getCompany().getCompanyNumber(), fesDocType,
+                        formTemplate.isSameDay(), tiffFiles, submittedAt));
+                LOGGER.debug(String.format(
+                    "Inserted submission details into FES DB for submission [%s], form [%s], same-day [%s]",
+                    submission.getId(), fesDocType, formTemplate.isSameDay() ? "Y" : "N"));
 
                 submissionService.updateSubmissionStatus(submission.getId(), SubmissionStatus.SENT_TO_FES);
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/FesLoaderServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/FesLoaderServiceImpl.java
@@ -115,6 +115,7 @@ public class FesLoaderServiceImpl implements FesLoaderService {
                 .withFormStatus(1L)
                 .withNumberOfPages(numberOfPages)
                 .withBarcodeDate(model.getBarcodeDate())
+                .withSameDayService(model.isSameDay())
                 .build();
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/fesloader/FormDao.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/fesloader/FormDao.java
@@ -24,6 +24,6 @@ public class FormDao {
             model.getFormType(), model.getImageId(), model.getEnvelopeId(), model.getFormStatus(),
             model.getNumberOfPages(), model.getFormType(), model.getCompanyName(),
             model.getCompanyNumber(), model.getBarcode(), Timestamp.valueOf(model.getBarcodeDate()),
-            "N");
+            model.getSameDayIndicator());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/model/FesLoaderModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/model/FesLoaderModel.java
@@ -1,8 +1,10 @@
 package uk.gov.companieshouse.efs.api.events.service.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class FesLoaderModel {
     private List<FesFileModel> tiffFiles;
@@ -12,23 +14,29 @@ public class FesLoaderModel {
     private String companyName;
     private String companyNumber;
     private String formType;
+    private boolean sameDay;
 
     public FesLoaderModel(String barcode, String companyName, String companyNumber, String formType,
-                          List<FesFileModel> tiffFiles, LocalDateTime barcodeDate) {
+        final boolean sameDay, List<FesFileModel> tiffFiles, LocalDateTime barcodeDate) {
         this.barcode = barcode;
         this.companyName = companyName;
         this.companyNumber = companyNumber;
         this.formType = formType;
+        this.sameDay = sameDay;
         this.tiffFiles = tiffFiles;
         this.barcodeDate = barcodeDate;
     }
 
     public List<FesFileModel> getTiffFiles() {
-        return tiffFiles;
+        return copyModelList(tiffFiles);
     }
 
     public void setTiffFiles(List<FesFileModel> tiffFiles) {
-        this.tiffFiles = tiffFiles;
+        this.tiffFiles = copyModelList(tiffFiles);
+    }
+
+    private List<FesFileModel> copyModelList(final List<FesFileModel> tiffFiles) {
+        return Optional.ofNullable(tiffFiles).map(ArrayList::new).orElse(null);
     }
 
     public LocalDateTime getBarcodeDate() {
@@ -71,6 +79,14 @@ public class FesLoaderModel {
         this.formType = formType;
     }
 
+    public boolean isSameDay() {
+        return sameDay;
+    }
+
+    public void setSameDay(final boolean sameDay) {
+        this.sameDay = sameDay;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -80,17 +96,16 @@ public class FesLoaderModel {
             return false;
         }
         final FesLoaderModel that = (FesLoaderModel) o;
-        return Objects.equals(getTiffFiles(), that.getTiffFiles()) && Objects
-            .equals(getBarcodeDate(), that.getBarcodeDate()) && Objects
-                   .equals(getBarcode(), that.getBarcode()) && Objects
-                   .equals(getCompanyName(), that.getCompanyName()) && Objects
-                   .equals(getCompanyNumber(), that.getCompanyNumber()) && Objects
-                   .equals(getFormType(), that.getFormType());
+        return isSameDay() == that.isSameDay() && Objects.equals(getTiffFiles(),
+            that.getTiffFiles()) && Objects.equals(getBarcodeDate(), that.getBarcodeDate())
+            && Objects.equals(getBarcode(), that.getBarcode()) && Objects.equals(getCompanyName(),
+            that.getCompanyName()) && Objects.equals(getCompanyNumber(), that.getCompanyNumber())
+            && Objects.equals(getFormType(), that.getFormType());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getTiffFiles(), getBarcodeDate(), getBarcode(), getCompanyName(),
-            getCompanyNumber(), getFormType());
+            getCompanyNumber(), getFormType(), isSameDay());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/model/FormModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/model/FormModel.java
@@ -1,7 +1,10 @@
 package uk.gov.companieshouse.efs.api.events.service.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 public class FormModel {
 
@@ -15,168 +18,128 @@ public class FormModel {
     private Integer numberOfPages;
     private Long formStatus;
     private LocalDateTime barcodeDate;
+    private boolean sameDayService;
 
-    public FormModel(Long envelopeId, String barcode, String companyName, String companyNumber, String formType, Long formId, Long imageId, Integer numberOfPages, Long formStatus, LocalDateTime barcodeDate) {
-        this.envelopeId = envelopeId;
-        this.barcode = barcode;
-        this.companyName = companyName;
-        this.companyNumber = companyNumber;
-        this.formType = formType;
-        this.formId = formId;
-        this.imageId = imageId;
-        this.numberOfPages = numberOfPages;
-        this.formStatus = formStatus;
-        this.barcodeDate = barcodeDate;
+    private FormModel() {
+        // no direct instantiation
     }
 
     public Long getEnvelopeId() {
         return envelopeId;
     }
 
-    public void setEnvelopeId(Long envelopeId) {
-        this.envelopeId = envelopeId;
-    }
-
     public String getBarcode() {
         return barcode;
-    }
-
-    public void setBarcode(String barcode) {
-        this.barcode = barcode;
     }
 
     public String getCompanyName() {
         return companyName;
     }
 
-    public void setCompanyName(String companyName) {
-        this.companyName = companyName;
-    }
-
     public String getCompanyNumber() {
         return companyNumber;
-    }
-
-    public void setCompanyNumber(String companyNumber) {
-        this.companyNumber = companyNumber;
     }
 
     public String getFormType() {
         return formType;
     }
 
-    public void setFormType(String formType) {
-        this.formType = formType;
-    }
-
     public Long getFormId() {
         return formId;
-    }
-
-    public void setFormId(Long formId) {
-        this.formId = formId;
     }
 
     public Long getImageId() {
         return imageId;
     }
 
-    public void setImageId(Long imageId) {
-        this.imageId = imageId;
-    }
-
     public Integer getNumberOfPages() {
         return numberOfPages;
-    }
-
-    public void setNumberOfPages(Integer numberOfPages) {
-        this.numberOfPages = numberOfPages;
     }
 
     public Long getFormStatus() {
         return formStatus;
     }
 
-    public void setFormStatus(Long formStatus) {
-        this.formStatus = formStatus;
-    }
-
     public LocalDateTime getBarcodeDate() {
         return barcodeDate;
-    }
-
-    public void setBarcodeDate(LocalDateTime barcodeDate) {
-        this.barcodeDate = barcodeDate;
     }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    public static class Builder {
-        private Long envelopeId;
-        private String barcode;
-        private String companyName;
-        private String companyNumber;
-        private String formType;
-        private Long formId;
-        private Long imageId;
-        private Integer numberOfPages;
-        private Long formStatus;
-        private LocalDateTime barcodeDate;
+    public String getSameDayIndicator() {
+        return sameDayService ? "Y" : "N";
+    }
 
+    public static class Builder {
+        private List<Consumer<FormModel>> buildSteps;
+
+        private Builder() {
+            buildSteps = new ArrayList<>();
+        }
+        
         public Builder withEnvelopeId(Long envelopeId) {
-            this.envelopeId = envelopeId;
+            buildSteps.add(data -> data.envelopeId = envelopeId);
             return this;
         }
 
         public Builder withBarcode(String barcode) {
-            this.barcode = barcode;
+            buildSteps.add(data -> data.barcode = barcode);
             return this;
         }
 
         public Builder withCompanyName(String companyName) {
-            this.companyName = companyName;
+            buildSteps.add(data -> data.companyName = companyName);
             return this;
         }
 
         public Builder withCompanyNumber(String companyNumber) {
-            this.companyNumber = companyNumber;
+            buildSteps.add(data -> data.companyNumber = companyNumber);
             return this;
         }
 
         public Builder withFormType(String formType) {
-            this.formType = formType;
+            buildSteps.add(data -> data.formType = formType);
             return this;
         }
 
         public Builder withFormId(Long formId) {
-            this.formId = formId;
+            buildSteps.add(data -> data.formId = formId);
             return this;
         }
 
         public Builder withImageId(Long imageId) {
-            this.imageId = imageId;
+            buildSteps.add(data -> data.imageId = imageId);
             return this;
         }
 
         public Builder withNumberOfPages(Integer numberOfPages) {
-            this.numberOfPages = numberOfPages;
+            buildSteps.add(data -> data.numberOfPages = numberOfPages);
             return this;
         }
 
         public Builder withFormStatus(Long formStatus) {
-            this.formStatus = formStatus;
+            buildSteps.add(data -> data.formStatus = formStatus);
             return this;
         }
 
         public Builder withBarcodeDate(LocalDateTime barcodeDate) {
-            this.barcodeDate = barcodeDate;
+            buildSteps.add(data -> data.barcodeDate = barcodeDate);
+            return this;
+        }
+        
+        public Builder withSameDayService(boolean sameDayService) {
+            buildSteps.add(data -> data.sameDayService = sameDayService);
             return this;
         }
 
         public FormModel build() {
-            return new FormModel(envelopeId, barcode, companyName, companyNumber, formType, formId, imageId, numberOfPages, formStatus, barcodeDate);
+            final FormModel data = new FormModel();
+            
+            buildSteps.forEach(step -> step.accept(data));
+            
+            return data;
         }
     }
 
@@ -189,22 +152,21 @@ public class FormModel {
             return false;
         }
         final FormModel formModel = (FormModel) o;
-        return Objects.equals(getEnvelopeId(), formModel.getEnvelopeId()) && Objects
-            .equals(getBarcode(), formModel.getBarcode()) && Objects
-                   .equals(getCompanyName(), formModel.getCompanyName()) && Objects
-                   .equals(getCompanyNumber(), formModel.getCompanyNumber()) && Objects
-                   .equals(getFormType(), formModel.getFormType()) && Objects
-                   .equals(getFormId(), formModel.getFormId()) && Objects
-                   .equals(getImageId(), formModel.getImageId()) && Objects
-                   .equals(getNumberOfPages(), formModel.getNumberOfPages()) && Objects
-                   .equals(getFormStatus(), formModel.getFormStatus()) && Objects
-                   .equals(getBarcodeDate(), formModel.getBarcodeDate());
+        return sameDayService == formModel.sameDayService && Objects.equals(getEnvelopeId(),
+            formModel.getEnvelopeId()) && Objects.equals(getBarcode(), formModel.getBarcode())
+            && Objects.equals(getCompanyName(), formModel.getCompanyName()) && Objects.equals(
+            getCompanyNumber(), formModel.getCompanyNumber()) && Objects.equals(getFormType(),
+            formModel.getFormType()) && Objects.equals(getFormId(), formModel.getFormId())
+            && Objects.equals(getImageId(), formModel.getImageId()) && Objects.equals(
+            getNumberOfPages(), formModel.getNumberOfPages()) && Objects.equals(getFormStatus(),
+            formModel.getFormStatus()) && Objects.equals(getBarcodeDate(),
+            formModel.getBarcodeDate());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getEnvelopeId(), getBarcode(), getCompanyName(), getCompanyNumber(),
             getFormType(), getFormId(), getImageId(), getNumberOfPages(), getFormStatus(),
-            getBarcodeDate());
+            getBarcodeDate(), sameDayService);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapper.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapper.java
@@ -21,6 +21,7 @@ public class FormTemplateMapper {
                         form.isAuthenticationRequired(),
                         form.isFesEnabled(),
                         form.getFesDocType(),
+                        form.isSameDay(),
                         new MessageTextListApi(form.getMessageTextIdList())))
                             .collect(Collectors.toCollection(FormTemplateListApi::new));
     }
@@ -34,6 +35,7 @@ public class FormTemplateMapper {
                         formTemplate.isAuthenticationRequired(),
                         formTemplate.isFesEnabled(),
                         formTemplate.getFesDocType(),
+                        formTemplate.isSameDay(),
                         new MessageTextListApi(formTemplate.getMessageTextIdList()));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplate.java
@@ -2,8 +2,11 @@ package uk.gov.companieshouse.efs.api.formtemplates.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.annotation.Id;
@@ -11,14 +14,23 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
- * Builder class for the {@code FormTemplate}.
+ * Entity class for the {@code FormTemplate}.
+ * formType: the form type
+ * formName: the form name
+ * formCategory: the form category
+ * fee: the form submission fee
+ * isAuthenticationRequired: is authentication required
+ * isFesEnabled: is fes enabled
+ * fesDocType: FES doc type (if different from formType, otherwise null)
+ * sameDay: is fes same day indicator required
+ * messageTextIdList: list of message textids
  */
 @Document(collection = "form_templates")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class FormTemplate {
 
     private FormTemplate() {
-        // required by Spring Data
+        // no direct instantiation
     }
 
     @JsonProperty("form_type")
@@ -48,34 +60,14 @@ public class FormTemplate {
     @JsonProperty("fes_doc_type")
     @Field
     private String fesDocType;
+    
+    @JsonProperty("same_day")
+    @Field
+    private boolean sameDay;
 
     @JsonProperty("message_text_list")
     @Field
     private List<Integer> messageTextIdList;
-
-    /**
-     * Constructor which sets the submission form data.
-     * @param formType the form type
-     * @param formName the form name
-     * @param formCategory the form category
-     * @param fee the form submission fee
-     * @param isAuthenticationRequired is authentication required
-     * @param isFesEnabled is fes enabled
-     * @param fesDocType FES doc type (if different from formType, otherwise null) 
-     * @param messageTextIdList list of message textids
-     */
-    public FormTemplate(final String formType, final String formName, final String formCategory, final String fee,
-        final boolean isAuthenticationRequired, final boolean isFesEnabled, final String fesDocType,
-        final List<Integer> messageTextIdList) {
-        this.formType = formType;
-        this.formName = formName;
-        this.formCategory = formCategory;
-        this.fee = fee;
-        this.isAuthenticationRequired = isAuthenticationRequired;
-        this.isFesEnabled = isFesEnabled;
-        this.fesDocType = fesDocType;
-        this.messageTextIdList = messageTextIdList;
-    }
 
     public String getFormType() {
         return formType;
@@ -105,12 +97,12 @@ public class FormTemplate {
         return fesDocType;
     }
 
-    public List<Integer> getMessageTextIdList() {
-        return messageTextIdList;
+    public boolean isSameDay() {
+        return sameDay;
     }
 
-    public void setMessageTextIdList(final List<Integer> messageTextIdList) {
-        this.messageTextIdList = messageTextIdList;
+    public List<Integer> getMessageTextIdList() {
+        return Optional.ofNullable(messageTextIdList).map(ArrayList::new).orElse(null);
     }
 
     @Override
@@ -122,17 +114,20 @@ public class FormTemplate {
             return false;
         }
         final FormTemplate that = (FormTemplate) o;
-        return isAuthenticationRequired() == that.isAuthenticationRequired() && isFesEnabled() == that.isFesEnabled()
-            && Objects.equals(getFormType(), that.getFormType()) && Objects.equals(getFormName(), that.getFormName())
-            && Objects.equals(getFormCategory(), that.getFormCategory()) && Objects.equals(getFee(), that.getFee())
-            && Objects.equals(getFesDocType(), that.getFesDocType()) && Objects.equals(getMessageTextIdList(),
+        return isAuthenticationRequired() == that.isAuthenticationRequired()
+            && isFesEnabled() == that.isFesEnabled() && isSameDay() == that.isSameDay()
+            && Objects.equals(getFormType(), that.getFormType()) && Objects.equals(getFormName(),
+            that.getFormName()) && Objects.equals(getFormCategory(), that.getFormCategory())
+            && Objects.equals(getFee(), that.getFee()) && Objects.equals(getFesDocType(),
+            that.getFesDocType()) && Objects.equals(getMessageTextIdList(),
             that.getMessageTextIdList());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getFormType(), getFormName(), getFormCategory(), getFee(), isAuthenticationRequired(),
-            isFesEnabled(), getFesDocType(), getMessageTextIdList());
+        return Objects.hash(getFormType(), getFormName(), getFormCategory(), getFee(),
+            isAuthenticationRequired(), isFesEnabled(), getFesDocType(), isSameDay(),
+            getMessageTextIdList());
     }
 
     @Override
@@ -145,7 +140,75 @@ public class FormTemplate {
                 .append("isAuthenticationRequired", isAuthenticationRequired())
                 .append("isFesEnabled", isFesEnabled())
                 .append("fesDocType", getFesDocType())
+                .append("sameDay", isSameDay())
                 .append("messageTextIdList", messageTextIdList)
                 .toString();
+    }
+    
+    public static FormTemplate.Builder builder() {
+        return new FormTemplate.Builder();
+    }
+    
+    public static class Builder {
+        private final List<Consumer<FormTemplate>> buildSteps;
+        
+        private Builder() {
+            buildSteps = new ArrayList<>();
+        }
+        
+        public FormTemplate.Builder withFormType(final String formType) {
+            buildSteps.add(data -> data.formType = formType);
+            return this;
+        }
+        
+        public FormTemplate.Builder withFormName(final String formName) {
+            buildSteps.add(data -> data.formName = formName);
+            return this;
+        }
+        
+        public FormTemplate.Builder withFormCategory(final String formCategory) {
+            buildSteps.add(data -> data.formCategory = formCategory);
+            return this;
+        }
+        
+        public FormTemplate.Builder withFee(final String fee) {
+            buildSteps.add(data -> data.fee = fee);
+            return this;
+        }
+
+        public FormTemplate.Builder withAuthenticationRequired(
+            final boolean authenticationRequired) {
+            buildSteps.add(data -> data.isAuthenticationRequired = authenticationRequired);
+            return this;
+        }
+        
+        public FormTemplate.Builder withFesEnabled(final boolean isFesEnabled) {
+            buildSteps.add(data -> data.isFesEnabled = isFesEnabled);
+            return this;
+        }
+        
+        public FormTemplate.Builder withFesDocType(final String fesDocType) {
+            buildSteps.add(data -> data.fesDocType = fesDocType);
+            return this;
+        }
+
+        public FormTemplate.Builder withSameDay(final boolean sameDay) {
+            buildSteps.add(data -> data.sameDay = sameDay);
+            return this;
+        }
+
+        public FormTemplate.Builder withMessageTextIdList(final List<Integer> messageTextIdList) {
+            buildSteps.add(data -> data.messageTextIdList =
+                Optional.ofNullable(messageTextIdList).map(ArrayList::new).orElse(null));
+            return this;
+        }
+        
+        public FormTemplate build() {
+            FormTemplate data = new FormTemplate();
+            
+            buildSteps.forEach(step -> step.accept(data));
+            
+            return data;
+        }
     }
 }

--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -2950,4 +2950,14 @@
   "isFesEnabled" : true,
   "messageTextIdList": [1,2]
 }
-]
+, {
+  "_id" : "SH19_SAMEDAY",
+  "formName" : "SH19 - Same Day service",
+  "formCategory" : "SH-RED-SAMEDAY",
+  "fee" : "SH19-SAMEDAY",
+  "isAuthenticationRequired" : true,
+  "isFesEnabled" : true,
+  "fesDocType": "SH19",
+  "isSameDay": true,
+  "messageTextIdList": [1,2]
+}]

--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -2954,7 +2954,7 @@
   "_id" : "SH19_SAMEDAY",
   "formName" : "SH19 - Same Day service",
   "formCategory" : "SH-RED-SAMEDAY",
-  "fee" : "SH19-SAMEDAY",
+  "fee" : "SH19_SAMEDAY",
   "isAuthenticationRequired" : true,
   "isFesEnabled" : true,
   "fesDocType": "SH19",

--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -2958,6 +2958,6 @@
   "isAuthenticationRequired" : true,
   "isFesEnabled" : true,
   "fesDocType": "SH19",
-  "isSameDay": true,
+  "sameDay": true,
   "messageTextIdList": [1,2]
 }]

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
@@ -133,8 +133,14 @@ class DecisionEngineTest {
                 .withFormType("AD01")
                 .build());
         when(timestampGenerator.generateTimestamp()).thenReturn(now);
-        when(formTemplateRepository.findById(anyString())).thenReturn(Optional.of(new FormTemplate("AD01", "Change of address", "CC", "", false, true,
-            "FES", null)));
+        when(formTemplateRepository.findById(anyString())).thenReturn(Optional.of(
+            FormTemplate.builder()
+                .withFormType("AD01")
+                .withFormName("Change of address")
+                .withFormCategory("CC")
+                .withFesEnabled(true)
+                .withFesDocType("FES")
+                .build()));
 
         //when
         Map<DecisionResult, List<Decision>> actual = decisionEngine
@@ -161,8 +167,13 @@ class DecisionEngineTest {
                 .withFormType("AD01")
                 .build());
         when(timestampGenerator.generateTimestamp()).thenReturn(now);
-        when(formTemplateRepository.findById(anyString())).thenReturn(Optional.of(new FormTemplate("AD01", "Change of address", "CC", "", false, false,
-            "FES", null)));
+        when(formTemplateRepository.findById(anyString())).thenReturn(Optional.of(
+            FormTemplate.builder()
+                .withFormType("AD01")
+                .withFormName("Change of address")
+                .withFormCategory("CC")
+                .withFesDocType("FES")
+                .build()));
 
         //when
         Map<DecisionResult, List<Decision>> actual = decisionEngine

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/EventServiceImplTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.efs.events.FileConversionResultStatusApi;
@@ -409,11 +411,13 @@ class EventServiceImplTest {
         verify(repository).read("123");
     }
 
-    @Test
-    void testSubmitToFes() {
+    @ParameterizedTest(name = "sameDayIndicator: {0}")
+    @ValueSource(strings = {"N", "Y"})
+    void testSubmitToFes(final String sameDayIndicator) {
         //given
         LocalDateTime now = LocalDateTime.now();
         String convertedFileId = "1234";
+        boolean sameDay = "Y".equalsIgnoreCase(sameDayIndicator);
         when(barcodeGeneratorService.getBarcode(any())).thenReturn("Y123XYZ");
         when(submission.getId()).thenReturn("1234abcd");
         when(repository.findByStatus(any(), anyInt())).thenReturn(Collections.singletonList(submission));
@@ -426,7 +430,8 @@ class EventServiceImplTest {
         when(formDetails.getFormType()).thenReturn("SH01");
         when(fileDetails.getConvertedFileId()).thenReturn(convertedFileId);
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, sameDay,
+                null));
 
         //when
         eventService.submitToFes();
@@ -437,7 +442,7 @@ class EventServiceImplTest {
         verify(barcodeGeneratorService, times(1)).getBarcode(now);
         verify(tiffDownloadService).downloadTiffFile(convertedFileId);
         verify(fesLoaderService).insertSubmission(new FesLoaderModel("Y123XYZ", "abc", "1223456",
-                "SH01", Collections.singletonList(new FesFileModel(null, 0)), now));
+                "SH01", sameDay, Collections.singletonList(new FesFileModel(null, 0)), now));
         verify(submissionService).updateSubmissionStatus(submission.getId(), SubmissionStatus.SENT_TO_FES);
     }
 
@@ -458,7 +463,7 @@ class EventServiceImplTest {
         when(formDetails.getFormType()).thenReturn("SH01");
         when(fileDetails.getConvertedFileId()).thenReturn(convertedFileId);
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, "FES-DOC-TYPE", null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, "FES-DOC-TYPE", false, null));
 
         //when
         eventService.submitToFes();
@@ -469,7 +474,7 @@ class EventServiceImplTest {
         verify(barcodeGeneratorService, times(1)).getBarcode(now);
         verify(tiffDownloadService).downloadTiffFile(convertedFileId);
         verify(fesLoaderService).insertSubmission(new FesLoaderModel("Y123XYZ", "abc", "1223456",
-                "FES-DOC-TYPE", Collections.singletonList(new FesFileModel(null, 0)), now));
+                "FES-DOC-TYPE", false, Collections.singletonList(new FesFileModel(null, 0)), now));
         verify(submissionService).updateSubmissionStatus(submission.getId(), SubmissionStatus.SENT_TO_FES);
     }
 
@@ -491,7 +496,7 @@ class EventServiceImplTest {
         when(formDetails.getFormType()).thenReturn("SH01");
         when(fileDetails.getConvertedFileId()).thenReturn(convertedFileId);
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, false, null));
 
         //when
         eventService.submitToFes();
@@ -502,7 +507,7 @@ class EventServiceImplTest {
         verify(barcodeGeneratorService, times(1)).getBarcode(now);
         verify(tiffDownloadService).downloadTiffFile(convertedFileId);
         verify(fesLoaderService).insertSubmission(new FesLoaderModel("Y123XYZ", "abc", "1223456",
-                "SH01", Collections.singletonList(new FesFileModel(null, 0)), now));
+                "SH01", false, Collections.singletonList(new FesFileModel(null, 0)), now));
         verify(submissionService).updateSubmissionStatus(submission.getId(), SubmissionStatus.SENT_TO_FES);
     }
 
@@ -531,7 +536,7 @@ class EventServiceImplTest {
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn("SH01");
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, false, null));
         when(barcodeGeneratorService.getBarcode(any())).thenReturn("Y123XYZ");
         when(tiffDownloadService.downloadTiffFile(any())).thenThrow(TiffDownloadException.class);
         when(formDetails.getFileDetailsList()).thenReturn(Collections.singletonList(fileDetails));
@@ -583,7 +588,7 @@ class EventServiceImplTest {
         when(formDetails.getFileDetailsList()).thenReturn(Collections.singletonList(fileDetails));
         when(formDetails.getFormType()).thenReturn("SH01");
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, false, null));
 
         when(fileDetails.getConvertedFileId()).thenReturn(convertedFileId);
 
@@ -608,7 +613,7 @@ class EventServiceImplTest {
         when(formDetails.getFileDetailsList()).thenReturn(Collections.singletonList(fileDetails));
         when(formDetails.getFormType()).thenReturn("SH01");
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, false, null));
         when(fileDetails.getConvertedFileId()).thenReturn(convertedFileId);
         when(barcodeGeneratorService.getBarcode(any())).thenReturn("Y123XYZ");
         when(repository.findByStatus(any(), anyInt())).thenReturn(Collections.singletonList(submission));
@@ -642,7 +647,7 @@ class EventServiceImplTest {
         when(formDetails.getFileDetailsList()).thenReturn(Collections.singletonList(fileDetails));
         when(formDetails.getFormType()).thenReturn("SH01");
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, false, null));
         when(fileDetails.getConvertedFileId()).thenReturn(convertedFileId);
 
         when(submission.getSubmittedAt()).thenReturn(now);
@@ -659,8 +664,8 @@ class EventServiceImplTest {
         verify(submissionService, times(1)).updateSubmissionBarcode("1234abcd", "Y123XYZ");
         verify(tiffDownloadService, times(1)).downloadTiffFile(convertedFileId);
         verify(fesLoaderService, times(1)).insertSubmission(
-                new FesLoaderModel("Y123XYZ", "abc", "1223456", "SH01",
-                        Collections.singletonList(new FesFileModel(null, 0)), now));
+                new FesLoaderModel("Y123XYZ", "abc", "1223456", "SH01", false,
+                    Collections.singletonList(new FesFileModel(null, 0)), now));
         verify(submissionService, times(1)).updateSubmissionStatus(submission.getId(), SubmissionStatus.SENT_TO_FES);
     }
 
@@ -681,7 +686,7 @@ class EventServiceImplTest {
         when(formDetails.getFormType()).thenReturn("SH01");
         when(formDetails.getBarcode()).thenReturn("Y9999999");
         when(formTemplateService.getFormTemplate("SH01")).thenReturn(
-            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, null));
+            new FormTemplateApi("SH01", "formName", "category", "", false, true, null, false, null));
 
         when(fileDetails.getConvertedFileId()).thenReturn(convertedFileId);
 
@@ -694,7 +699,7 @@ class EventServiceImplTest {
         verifyNoInteractions(barcodeGeneratorService);
         verify(tiffDownloadService).downloadTiffFile(convertedFileId);
         verify(fesLoaderService).insertSubmission(new FesLoaderModel("Y9999999", "abc", "1223456",
-                "SH01", Collections.singletonList(new FesFileModel(null, 0)), now));
+                "SH01", false, Collections.singletonList(new FesFileModel(null, 0)), now));
         verify(submissionService).updateSubmissionStatus(submission.getId(), SubmissionStatus.SENT_TO_FES);
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/FesLoaderServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/FesLoaderServiceImplTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -77,8 +79,9 @@ class FesLoaderServiceImplTest {
         this.fesLoaderService = new FesLoaderServiceImpl(batchDao, envelopeDao, dateGenerator, imageDao, formDao);
     }
 
-    @Test
-    void testInsertSubmission() throws IOException {
+    @ParameterizedTest(name = "sameDayIndicator: {0}")
+    @ValueSource(strings = {"N", "Y"})
+    void testInsertSubmission(final String sameDayIndicator) throws IOException {
 
         // given
         LocalDateTime someDate = LocalDateTime.of(2020, Month.MAY, 1, 12, 0);
@@ -96,6 +99,7 @@ class FesLoaderServiceImplTest {
         when(model.getCompanyName()).thenReturn(COMPANY_NAME);
         when(model.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(model.getFormType()).thenReturn(FORM_TYPE);
+        when(model.isSameDay()).thenReturn("Y".equalsIgnoreCase(sameDayIndicator));
 
         // when
         fesLoaderService.insertSubmission(model);
@@ -116,6 +120,7 @@ class FesLoaderServiceImplTest {
         assertEquals(COMPANY_NAME, formModelCaptor.getValue().getCompanyName());
         assertEquals(COMPANY_NUMBER, formModelCaptor.getValue().getCompanyNumber());
         assertEquals(FORM_TYPE, formModelCaptor.getValue().getFormType());
+        assertEquals(sameDayIndicator, formModelCaptor.getValue().getSameDayIndicator());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/fesloader/FormDaoTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/fesloader/FormDaoTest.java
@@ -1,19 +1,20 @@
 package uk.gov.companieshouse.efs.api.events.service.fesloader;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
 import uk.gov.companieshouse.efs.api.events.service.model.FormModel;
-
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class FormDaoTest {
@@ -37,19 +38,23 @@ class FormDaoTest {
         this.formDao = new FormDao(jdbcTemplate);
     }
 
-    @Test
-    void testFormDaoInsertsNewForm() {
+    @ParameterizedTest(name = "isSameDay: {0}")
+    @ValueSource(booleans = {false, true})
+    void testFormDaoInsertsNewFormWhen(final boolean isSameDay) {
         //given
         LocalDateTime now = LocalDateTime.now();
 
         //when
-        this.formDao.insertForm(getFormModel(now));
+        this.formDao.insertForm(getFormModel(now, isSameDay));
 
         //then
-        verify(jdbcTemplate).update(anyString(), eq(BARCODE), eq(COMPANY_NUMBER), eq(COMPANY_NAME), eq(FORM_TYPE), eq(IMAGE_ID), eq(ENVELOPE_ID), eq(FORM_STATUS), eq(NUMBER_OF_PAGES), eq(FORM_TYPE), eq(COMPANY_NAME), eq(COMPANY_NUMBER), eq(BARCODE), eq(Timestamp.valueOf(now)), eq("N"));
+        verify(jdbcTemplate).update(anyString(), eq(BARCODE), eq(COMPANY_NUMBER), eq(COMPANY_NAME),
+            eq(FORM_TYPE), eq(IMAGE_ID), eq(ENVELOPE_ID), eq(FORM_STATUS), eq(NUMBER_OF_PAGES),
+            eq(FORM_TYPE), eq(COMPANY_NAME), eq(COMPANY_NUMBER), eq(BARCODE),
+            eq(Timestamp.valueOf(now)), eq(isSameDay ? "Y" : "N"));
     }
 
-    private FormModel getFormModel(LocalDateTime now) {
+    private FormModel getFormModel(LocalDateTime now, final boolean isSameDay) {
         return FormModel.builder()
                 .withBarcode(BARCODE)
                 .withCompanyNumber(COMPANY_NUMBER)
@@ -60,6 +65,7 @@ class FormDaoTest {
                 .withFormStatus(FORM_STATUS)
                 .withNumberOfPages(NUMBER_OF_PAGES)
                 .withBarcodeDate(now)
+                .withSameDayService(isSameDay)
                 .build();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/model/FesLoaderModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/model/FesLoaderModelTest.java
@@ -1,0 +1,93 @@
+package uk.gov.companieshouse.efs.api.events.service.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class FesLoaderModelTest {
+    private FesLoaderModel testModel;
+    private List<FesFileModel> fileModelList;
+    private LocalDateTime now;
+    private FesFileModel tiffFile;
+
+    @BeforeEach
+    void setUp() {
+        now = LocalDateTime.now();
+        tiffFile = new FesFileModel(new byte[] {0x70}, 1);
+        fileModelList = Collections.singletonList(tiffFile);
+        testModel = new FesLoaderModel("barcode", "company-name", "company-number", "form", false,
+            fileModelList, now);
+    }
+
+    @Test
+    void constructor() {
+        assertThat(testModel.getFormType(), is("form"));
+        assertThat(testModel.getCompanyName(), is("company-name"));
+        assertThat(testModel.getCompanyNumber(), is("company-number"));
+        assertThat(testModel.getBarcode(), is("barcode"));
+        assertThat(testModel.getBarcodeDate(), is(now));
+        assertThat(testModel.isSameDay(), is(false));
+        assertThat(testModel.getTiffFiles(), contains(tiffFile));
+    }
+
+    @Test
+    void setTiffFiles() {
+        testModel.setTiffFiles(null);
+        assertThat(testModel.getTiffFiles(), is(nullValue()));
+    }
+
+    @Test
+    void setBarcodeDate() {
+        testModel.setBarcodeDate(null);
+        assertThat(testModel.getBarcodeDate(), is(nullValue()));
+    }
+
+    @Test
+    void setBarcode() {
+        testModel.setBarcode(null);
+        assertThat(testModel.getBarcode(), is(nullValue()));
+    }
+
+    @Test
+    void setCompanyName() {
+        testModel.setCompanyName(null);
+        assertThat(testModel.getCompanyName(), is(nullValue()));
+    }
+
+    @Test
+    void setCompanyNumber() {
+        testModel.setCompanyNumber(null);
+        assertThat(testModel.getCompanyNumber(), is(nullValue()));
+    }
+
+    @Test
+    void setFormType() {
+        testModel.setFormType(null);
+        assertThat(testModel.getFormType(), is(nullValue()));
+    }
+
+    @Test
+    void setSameDay() {
+        testModel.setSameDay(true);
+        assertThat(testModel.isSameDay(), is(true));
+    }
+
+    @Test
+    void testEqualsAndHashcode() {
+        EqualsVerifier.forClass(FesLoaderModel.class).usingGetClass().suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/model/FormModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/model/FormModelTest.java
@@ -1,0 +1,108 @@
+package uk.gov.companieshouse.efs.api.events.service.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.LocalDateTime;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FormModelTest {
+    private static final LocalDateTime BARCODE_DATE = LocalDateTime.now();
+    private static final Long FORM_STATUS = 1L;
+    private static final Long FORM_ID = 3000L;
+    private static final Long ENVELOPE_ID = 4000L;
+    private static final Long IMAGE_ID = 5000L;
+
+    private FormModel testModel;
+
+    @BeforeEach
+    void setUp() {
+        testModel = FormModel.builder()
+            .withFormId(FORM_ID)
+            .withFormType("form")
+            .withFormStatus(FORM_STATUS)
+            .withBarcode("barcode")
+            .withBarcodeDate(BARCODE_DATE)
+            .withCompanyName("company-name")
+            .withCompanyNumber("company-number")
+            .withEnvelopeId(ENVELOPE_ID)
+            .withImageId(IMAGE_ID)
+            .withNumberOfPages(2)
+            .withSameDayService(true)
+            .build();
+    }
+
+    @Test
+    void getEnvelopeId() {
+        assertThat(testModel.getEnvelopeId(), is(ENVELOPE_ID));
+    }
+
+    @Test
+    void getBarcode() {
+        assertThat(testModel.getBarcode(), is("barcode"));
+    }
+
+    @Test
+    void getCompanyName() {
+        assertThat(testModel.getCompanyName(), is("company-name"));
+    }
+
+    @Test
+    void getCompanyNumber() {
+        assertThat(testModel.getCompanyNumber(), is("company-number"));
+    }
+
+    @Test
+    void getFormType() {
+        assertThat(testModel.getFormType(), is("form"));
+    }
+
+    @Test
+    void getFormId() {
+        assertThat(testModel.getFormId(), is(FORM_ID));
+    }
+
+    @Test
+    void getImageId() {
+        assertThat(testModel.getImageId(), is(IMAGE_ID));
+    }
+
+    @Test
+    void getNumberOfPages() {
+        assertThat(testModel.getNumberOfPages(), is(2));
+    }
+
+    @Test
+    void getFormStatus() {
+        assertThat(testModel.getFormStatus(), is(FORM_STATUS));
+    }
+
+    @Test
+    void getBarcodeDate() {
+        assertThat(testModel.getBarcodeDate(), is(BARCODE_DATE));
+    }
+
+    @Test
+    void getSameDayIndicator() {
+        assertThat(testModel.getSameDayIndicator(), is("Y"));
+    }
+
+    @Test
+    void GetSameDayIndicatorWhenFalse() {
+        assertThat(FormModel.builder().build().getSameDayIndicator(), is("N"));
+    }
+
+    @Test
+    void testEqualsAndHashcode() {
+        EqualsVerifier.forClass(FormModel.class)
+            .usingGetClass()
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/mapper/FormTemplateMapperTest.java
@@ -23,66 +23,76 @@ class FormTemplateMapperTest {
     @Test
     void testMapperMapsListOfFormsToFormListApi() {
         //given
-        List<FormTemplate> formTemplates = Collections.singletonList(getForm(Arrays.asList(1, 2, 3)));
+        List<FormTemplate> formTemplates =
+            Collections.singletonList(getForm(Arrays.asList(1, 2, 3), false));
 
         //when
         FormTemplateListApi actual = mapper.map(formTemplates);
 
         //then
-        assertEquals(expectedList(Arrays.asList(1, 2, 3)), actual);
+        assertEquals(expectedList(Arrays.asList(1, 2, 3), false), actual);
     }
 
     @Test
     void testMapperMapsCategoryToCategoryTemplateApi() {
         //given
         final List<Integer> messageTextIdList = Arrays.asList(1, 2, 3);
-        FormTemplate formTemplate = getForm(messageTextIdList);
+        FormTemplate formTemplate = getForm(messageTextIdList, false);
 
         //when
         FormTemplateApi actual = mapper.map(formTemplate);
 
         //then
-        assertEquals(expectedSingle(messageTextIdList), actual);
+        assertEquals(expectedSingle(messageTextIdList, false), actual);
     }
 
     @Test
     void testMapperMapsCategoryToCategoryTemplateApiWhenFormTemplateMessageTextListNull() {
         //given
-        FormTemplate formTemplate = getForm(null);
+        FormTemplate formTemplate = getForm(null, false);
 
         //when
         FormTemplateApi actual = mapper.map(formTemplate);
 
         //then
-        assertEquals(expectedSingle(null), actual);
+        assertEquals(expectedSingle(null, false), actual);
     }
 
     @Test
     void testMapperMapsCategoryToCategoryTemplateApiWhenFormTemplateMessageTextListEmpty() {
         //given
-        FormTemplate formTemplate = getForm(Collections.emptyList());
+        FormTemplate formTemplate = getForm(Collections.emptyList(), false);
 
         //when
         FormTemplateApi actual = mapper.map(formTemplate);
 
         //then
-        assertEquals(expectedSingle(Collections.singletonList(0)), actual);
+        assertEquals(expectedSingle(Collections.singletonList(0), false), actual);
     }
 
-    private FormTemplate getForm(final List<Integer> messageTextIdList) {
-        return new FormTemplate("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, null, messageTextIdList);
+    private FormTemplate getForm(final List<Integer> messageTextIdList, final boolean sameDay) {
+        return FormTemplate.builder()
+            .withFormType("IN01")
+            .withFormName("New Incorporation")
+            .withFormCategory("NEWINC")
+            .withFee("12")
+            .withSameDay(sameDay)
+            .withMessageTextIdList(messageTextIdList).build();
     }
 
-    private FormTemplateListApi expectedList(final List<Integer> messageTextIdList) {
-        FormTemplateApi element = new FormTemplateApi("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, null, new MessageTextListApi(messageTextIdList));
+    private FormTemplateListApi expectedList(final List<Integer> messageTextIdList,
+        final boolean sameDay) {
+        FormTemplateApi element =
+            new FormTemplateApi("IN01", "New Incorporation", "NEWINC", "12", false, false, null,
+                sameDay, new MessageTextListApi(messageTextIdList));
         return new FormTemplateListApi(Collections.singletonList(element));
     }
 
-    private FormTemplateApi expectedSingle(final List<Integer> messageTextIdList) {
-        FormTemplateApi element = new FormTemplateApi("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, null, new MessageTextListApi(messageTextIdList));
+    private FormTemplateApi expectedSingle(final List<Integer> messageTextIdList,
+        final boolean sameDay) {
+        FormTemplateApi element =
+            new FormTemplateApi("IN01", "New Incorporation", "NEWINC", "12", false, false, null,
+                sameDay, new MessageTextListApi(messageTextIdList));
         return new FormTemplateApi(element);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
@@ -2,8 +2,10 @@ package uk.gov.companieshouse.efs.api.formtemplates.model;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.Matchers;
@@ -20,7 +22,17 @@ class FormTemplateTest {
 
     @BeforeEach
     void setUp() {
-        testFormTemplate = new FormTemplate("CC01", "Form01", "CC", "100", false, true, "FES", null);
+        testFormTemplate = FormTemplate.builder()
+            .withFormType("CC01")
+            .withFormName("Form01")
+            .withFormCategory("CC")
+            .withFee("100")
+            .withAuthenticationRequired(true)
+            .withFesEnabled(true)
+            .withFesDocType("FES")
+            .withSameDay(true)
+            .withMessageTextIdList(Arrays.asList(1, 2, 3))
+            .build();
         JacksonTester.initFields(this, new ObjectMapper());
     }
 
@@ -31,6 +43,10 @@ class FormTemplateTest {
         assertThat(testFormTemplate.getFormName(), is("Form01"));
         assertThat(testFormTemplate.getFormCategory(), is("CC"));
         assertThat(testFormTemplate.getFee(), is("100"));
+        assertThat(testFormTemplate.isAuthenticationRequired(), is(true));
+        assertThat(testFormTemplate.isFesEnabled(), is(true));
+        assertThat(testFormTemplate.isSameDay(), is(true));
+        assertThat(testFormTemplate.getMessageTextIdList(), contains(1, 2, 3));
     }
 
     @Test
@@ -43,8 +59,9 @@ class FormTemplateTest {
     void toStringTest() {
         assertThat(testFormTemplate.toString(), Matchers.is(
                 //@formatter:off
-                "FormTemplate[formType=CC01,formName=Form01,formCategory=CC,fee=100," +
-                        "isAuthenticationRequired=false,isFesEnabled=true,fesDocType=FES,messageTextIdList=<null>]"
+                "FormTemplate[formType=CC01,formName=Form01,formCategory=CC,fee=100,"
+                    + "isAuthenticationRequired=true,isFesEnabled=true,fesDocType=FES," 
+                    + "sameDay=true,messageTextIdList=[1, 2, 3]]"
                 //@formatter:on
         ));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
@@ -73,10 +73,16 @@ class FormTemplateServiceImplTest {
 
         //given
         String categoryId = "CC01";
-        FormTemplate formTemplate = new FormTemplate("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, "FES", null);
-        FormTemplateApi mappedForm = new FormTemplateApi("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, "FES", null);
+        FormTemplate formTemplate = FormTemplate.builder()
+            .withFormType("IN01")
+            .withFormName("New Incorporation")
+            .withFormCategory("NEWINC")
+            .withFee("12")
+            .withFesDocType("FES")
+            .build();
+        FormTemplateApi mappedForm =
+            new FormTemplateApi("IN01", "New Incorporation", "NEWINC", "12", false, false, "FES",
+                false, null);
 
         when(formRepository.findById(categoryId)).thenReturn(Optional.of(formTemplate));
         when(mapper.map(formTemplate)).thenReturn(mappedForm);
@@ -108,8 +114,13 @@ class FormTemplateServiceImplTest {
 
         //given
         String categoryId = "CC01";
-        FormTemplate mappedForm = new FormTemplate("IN01", "New Incorporation", "NEWINC", "12",
-                false, false, "FES", null);
+        FormTemplate mappedForm = FormTemplate.builder()
+            .withFormType("IN01")
+            .withFormName("New Incorporation")
+            .withFormCategory("NEWINC")
+            .withFee("12")
+            .withFesDocType("FES")
+            .build();
 
         List<FormTemplate> listForm = new ArrayList<>();
         listForm.add(mappedForm);

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
@@ -105,7 +105,7 @@ class PaymentControllerTest {
         final SubmissionApi submission = new SubmissionMapper().map(
             new Submission.Builder().withFormDetails(formDetails).withCompany(company).build());
         final FormTemplateApi formTemplate =
-            new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, null);
+            new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
         final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
@@ -208,7 +208,7 @@ class PaymentControllerTest {
         SubmissionApi submission =
             new SubmissionMapper().map(new Submission.Builder().withFormDetails(formDetails).build());
         final FormTemplateApi formTemplate =
-            new FormTemplateApi(NOCHARGE, "no charge", null, null, false, false, null, null);
+            new FormTemplateApi(NOCHARGE, "no charge", null, null, false, false, null, false, null);
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(NOCHARGE)).thenReturn(formTemplate);
@@ -227,7 +227,7 @@ class PaymentControllerTest {
         SubmissionApi submission =
             new SubmissionMapper().map(new Submission.Builder().withFormDetails(formDetails).build());
         final FormTemplateApi formTemplate =
-            new FormTemplateApi(NOCHARGE, "no charge", null, "", false, false, null, null);
+            new FormTemplateApi(NOCHARGE, "no charge", null, "", false, false, null, false, null);
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(NOCHARGE)).thenReturn(formTemplate);
@@ -246,7 +246,8 @@ class PaymentControllerTest {
         SubmissionApi submission =
             new SubmissionMapper().map(new Submission.Builder().withFormDetails(formDetails).build());
         final FormTemplateApi formTemplate =
-            new FormTemplateApi(NOCHARGE, "no charge", null, UNKNOWN, false, false, null, null);
+            new FormTemplateApi(NOCHARGE, "no charge", null, UNKNOWN, false, false, null, false,
+                null);
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(NOCHARGE)).thenReturn(formTemplate);
@@ -265,7 +266,7 @@ class PaymentControllerTest {
         SubmissionApi submission = new SubmissionMapper().map(
             new Submission.Builder().withFormDetails(formDetails).withCompany(company).build());
         final FormTemplateApi formTemplate =
-            new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, null);
+            new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
         final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
@@ -286,7 +287,8 @@ class PaymentControllerTest {
         final FormDetails formDetails = new FormDetails(FORM, CHARGED, null);
         SubmissionApi submission = new SubmissionMapper()
             .map(new Submission.Builder().withFormDetails(formDetails).build());
-        final FormTemplateApi formTemplate = new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, null);
+        final FormTemplateApi formTemplate =
+            new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
         final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
@@ -308,7 +310,8 @@ class PaymentControllerTest {
         final FormDetails formDetails = new FormDetails(FORM, CHARGED, null);
         SubmissionApi submission = new SubmissionMapper()
             .map(new Submission.Builder().withFormDetails(formDetails).withCompany(company).build());
-        final FormTemplateApi formTemplate = new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, null);
+        final FormTemplateApi formTemplate =
+            new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
         final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/FormTemplateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/validator/FormTemplateValidatorTest.java
@@ -57,7 +57,7 @@ class FormTemplateValidatorTest {
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(formDetails.getFormType()).thenReturn("FORM");
         when(formRepository.findById("FORM")).thenReturn(
-            Optional.of(new FormTemplate(null, null, null, null, false, false, null, null)));
+            Optional.of(FormTemplate.builder().build()));
 
         testValidator.validate(submission);
 


### PR DESCRIPTION
- update API spec; add form template property isSameDayService
- update API spec; change /form-template path param to query param
- use FormTemplateApi property isSameDay()
- apply builder pattern to FormModel
- apply builder pattern to FormTemplate
- add SH19_SAMEDAY to form_templates.json
- include unit test coverage

Resolves:
BI-7848