### PR TITLE
Add payment template SH19 sameday

### DIFF
--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -64,7 +64,7 @@
   },
   {
     "_id": "SH19-SAMEDAY",
-    "description": "Upload form SH19 (Same day service)",
+    "description": "Upload form SH19",
     "etag": "FB9F50ED470E23678519F3AE0E84F31587C43ED8",
     "items": [
       {
@@ -75,7 +75,7 @@
         "class_of_payment": [
           "data-maintenance"
         ],
-        "description": "Upload a document to Companies House: SH19 (Same day service)",
+        "description": "Upload a document to Companies House: SH19",
         "description_identifier": "EFS_SH19_SAMEDAY",
         "kind": "cost#cost",
         "product_type": "efs-sh19-same-day"

--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -63,7 +63,7 @@
     "kind": "EFS"
   },
   {
-    "_id": "SH19-SAMEDAY",
+    "_id": "SH19_SAMEDAY",
     "description": "Upload form SH19",
     "etag": "FB9F50ED470E23678519F3AE0E84F31587C43ED8",
     "items": [

--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -61,5 +61,26 @@
       }
     ],
     "kind": "EFS"
+  },
+  {
+    "_id": "SH19-SAMEDAY",
+    "description": "Upload form SH19 (Same day service)",
+    "etag": "FB9F50ED470E23678519F3AE0E84F31587C43ED8",
+    "items": [
+      {
+        "amount": "50",
+        "available_payment_methods": [
+          "credit-card"
+        ],
+        "class_of_payment": [
+          "data-maintenance"
+        ],
+        "description": "Upload a document to Companies House: SH19 (Same day service)",
+        "description_identifier": "EFS_SH19_SAMEDAY",
+        "kind": "cost#cost",
+        "product_type": "efs-sh19-same-day"
+      }
+    ],
+    "kind": "EFS"
   }
 ]


### PR DESCRIPTION
- `_id` is what we've agreed for a new form in the form_templates
- `product_type` aligns with the prod code in the [payment reconciliation PR](https://github.com/companieshouse/payment-reconciliation-consumer/pull/36)
- `description_identifier` is what I assume is correct

I've tested by adding a SH19_SAMEDAY to my form_templates and payment service is as expected

BI-7846