### PR TITLE
Add support for SH19 same day form

### DIFF
--- a/src/main/resources/category_templates.json
+++ b/src/main/resources/category_templates.json
@@ -174,6 +174,11 @@
   "categoryHint": "Form SH19, solvency statement, statement by directors and resolution",
   "parent": "SH",
   "guidanceTexts": [0]
+}, {
+  "_id": "SH-RED-SAMEDAY",
+  "categoryName": "Dummy category for SH19_SAMEDAY",
+  "categoryHint": "parent is self to exclude from category hierarchy",
+  "parent": "SH-RED-SAMEDAY"
 },{
   "_id": "SH-OTHER",
   "categoryName": "Other share capital documents",

--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -2952,7 +2952,7 @@
 }
 , {
   "_id" : "SH19_SAMEDAY",
-  "formName" : "SH19 - Same Day service",
+  "formName" : "SH19 - Statement of capital when reducing capital in a company",
   "formCategory" : "SH-RED-SAMEDAY",
   "fee" : "SH19_SAMEDAY",
   "isAuthenticationRequired" : true,


### PR DESCRIPTION
Update Category and Form templates for SH19 same day

- add parent category for form `SH19_SAMEDAY` outside category hierarchy
- update `SH19_SAMEDAY` description to meet requirements on Check Details page

### Requirements
- requires `efs-submissions-web` changes for BI-7844 (PR pending); do not apply beforehand

Resolves:
BI-7844

See also:
BI-8066