### PR TITLE
Filter paymentTransactions starting with SH19 instead of equal to SH19

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
@@ -108,7 +108,8 @@ public class PaymentReportServiceImpl implements PaymentReportService {
     @Override
     public void sendFinancePaymentReports() throws IOException {
         List<PaymentTransaction> sh19Transactions =
-            findPaymentTransactions(SUCCESSFUL_STATUSES).stream().filter(p -> StringUtils.equals("SH19", p.getFormType()))
+            findPaymentTransactions(SUCCESSFUL_STATUSES).stream()
+                .filter(p -> StringUtils.startsWith(p.getFormType(), "SH19"))
                 .collect(Collectors.toList());
         createReport(sh19FinanceReportPattern, sh19Transactions);
         createReport(failedTransactionsFinanceReportPattern, findPaymentTransactions(FAILED_STATUSES));

--- a/src/test/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImplTest.java
@@ -255,6 +255,7 @@ class PaymentReportServiceImplTest {
         assertThat(values.get(0).getHasNoPaymentTransactions(), is(false));
         assertThat(values.get(0).getFileLink(), is(successFileLink));
         assertThat(values.get(0).getFileName(), is(sh19ReportName.replace(".csv", "")));
+        assertThat(values.get(1).getHasNoPaymentTransactions(), is(false));
         assertThat(values.get(1).getFileLink(), is(failedFileLink));
         assertThat(values.get(1).getFileName(), is(failedReportName.replace(".csv", "")));
 
@@ -282,6 +283,7 @@ class PaymentReportServiceImplTest {
         assertThat(values.get(0).getHasNoPaymentTransactions(), is(true));
         assertThat(values.get(0).getFileLink(), is(successFileLink));
         assertThat(values.get(0).getFileName(), is(sh19ReportName.replace(".csv", "")));
+        assertThat(values.get(1).getHasNoPaymentTransactions(), is(true));
         assertThat(values.get(1).getFileLink(), is(failedFileLink));
         assertThat(values.get(1).getFileName(), is(failedReportName.replace(".csv", "")));
 


### PR DESCRIPTION
BI-7969 & defect BI-8465

Unit test amended/added to check presence of transactions when SH19 / SH19_SAMEDAY submissions - (credit @hepsimo)

Report now includes all SH19's:
<img width="1134" alt="Screenshot 2021-07-02 at 12 53 52" src="https://user-images.githubusercontent.com/2736331/124271134-01825380-db35-11eb-96da-cbb606cbd0ae.png">
