### PR TITLE
Fix bug in getTopLevelCategory() for SH-RED-SAMEDAY

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImpl.java
@@ -67,7 +67,7 @@ public class CategoryTemplateServiceImpl implements CategoryTemplateService {
                 final CategoryTypeConstants parentCategoryType =
                     CategoryTypeConstants.nameOf(parentCategory).orElse(OTHER);
 
-                if (parentCategoryType == ROOT) {
+                if (parentCategoryType == ROOT || parentCategory.equals(category)) {
                     return result;
                 } else {
                     result = parentCategoryType;

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
@@ -152,4 +152,20 @@ class CategoryTemplateServiceImplTest {
         //then
         assertThat(topLevelCategory, is(nullValue()));
     }
+
+    @Test
+    void getTopLevelCategoryWhenParentIsSelf() {
+        // given
+        final CategoryTemplate category =
+            new CategoryTemplate("SELF_PARENT", "parent is self", "SELF_PARENT", null, null);
+
+        when(categoryRepository.findById(category.getCategoryType())).thenReturn(
+            Optional.of(category));
+
+        //when
+        final CategoryTypeConstants topLevelCategory =
+            service.getTopLevelCategory(category.getCategoryType());
+
+        assertThat(topLevelCategory.getValue(), is(OTHER.getValue()));
+    }
 }


### PR DESCRIPTION
- avoid infinite loop in `getTopLevelCategory()` for a category having itself in hierarchy, e.g. SH-RED-SAMEDAY has parent=SH-RED-SAMEDAY

Resolves:
BI-8490