### PR TITLE
Notify suport delayed sh19 sameday issue

### DIFF
--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -797,8 +797,22 @@
       }
     },
     "/events/handle-delayed-submissions": {
+      "parameters": [
+        {
+          "in": "query",
+          "name": "service",
+          "description": "Service level of submission to handle, default: Standard",
+          "required": false,
+          "type": "string",
+          "enum": [
+            "STANDARD",
+            "SAMEDAY"
+          ],
+          "x-example": "SAMEDAY"
+        }
+      ],
       "post": {
-        "summary": "Poll for submissions stuck in PROCESSING and notify relevant teams",
+        "summary": "Poll for submissions stuck in EFS and notify relevant teams",
         "x-operationName": "notifySubmissionsStuck",
         "tags": [
           "notify submissions stuck",

--- a/src/main/java/uk/gov/companieshouse/efs/api/config/Config.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/config/Config.java
@@ -293,6 +293,8 @@ public class Config {
                 internalEmailMapperFactory.getDelayedSubmissionBusinessMapper())
             .withDelayedSubmissionSupportEmailMapper(
                 internalEmailMapperFactory.getDelayedSubmissionSupportMapper())
+            .withDelayedSH19SameDaySubmissionSupportEmailMapper(
+                internalEmailMapperFactory.getDelayedSH19SameDaySubmissionSupportEmailMapper())
             .withInternalAvFailedEmailMapper(internalEmailMapperFactory.getInternalAvFailedMapper())
             .withInternalFailedConversionEmailMapper(
                 internalEmailMapperFactory.getInternalFailedConversionMapper())

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/EmailService.java
@@ -27,6 +27,8 @@ public interface EmailService {
 
     void sendDelayedSubmissionSupportEmail(DelayedSubmissionSupportEmailModel delayedSubmissionSupportEmailModel);
 
+    void sendDelayedSH19SubmissionSupportEmail(DelayedSubmissionSupportEmailModel delayedSubmissionSupportEmailModel);
+
     void sendDelayedSubmissionBusinessEmail(DelayedSubmissionBusinessEmailModel emailModel);
 
     void sendPaymentReportEmail(PaymentReportEmailModel emailModel);

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/EmailServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/EmailServiceImpl.java
@@ -104,6 +104,13 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
+    public void sendDelayedSH19SubmissionSupportEmail(DelayedSubmissionSupportEmailModel emailModel) {
+        LOGGER.debug(String.format("Sending delayed SH19 same day submission support email for [%d] submissions",
+                emailModel.getNumberOfDelayedSubmissions()));
+        sendMessage(this.emailMapperFactory.getDelayedSH19SameDaySubmissionSupportEmailMapper().map(emailModel));
+    }
+
+    @Override
     public void sendDelayedSubmissionBusinessEmail(DelayedSubmissionBusinessEmailModel emailModel) {
         LOGGER.debug(String.format("Sending delayed submission business email for [%d] submissions",
                 emailModel.getNumberOfDelayedSubmissions()));

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfig.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfig.java
@@ -6,8 +6,8 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
 @Component
-@PropertySource("classpath:delayed.submission.support.mail.properties")
-@ConfigurationProperties(prefix = "delayed.sh19_sameday.submission.support.mail")
+@PropertySource("classpath:delayed.sh19.sameday.submission.support.mail.properties")
+@ConfigurationProperties(prefix = "delayed.sh19.sameday.submission.support.mail")
 public class DelayedSH19SameDaySubmissionSupportEmailConfig extends EmailConfig {
 
     private String supportEmailAddress;

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfig.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfig.java
@@ -1,0 +1,43 @@
+package uk.gov.companieshouse.efs.api.email.config;
+
+import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Component
+@PropertySource("classpath:delayed.submission.support.mail.properties")
+@ConfigurationProperties(prefix = "delayed.sh19_sameday.submission.support.mail")
+public class DelayedSH19SameDaySubmissionSupportEmailConfig extends EmailConfig {
+
+    private String supportEmailAddress;
+
+    public String getSupportEmailAddress() {
+        return supportEmailAddress;
+    }
+
+    public void setSupportEmailAddress(String supportEmailAddress) {
+        this.supportEmailAddress = supportEmailAddress;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final DelayedSH19SameDaySubmissionSupportEmailConfig
+            that = (DelayedSH19SameDaySubmissionSupportEmailConfig) o;
+        return Objects.equals(getSupportEmailAddress(), that.getSupportEmailAddress());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getSupportEmailAddress());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSH19SameDaySubmissionSupportEmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSH19SameDaySubmissionSupportEmailMapper.java
@@ -51,6 +51,7 @@ public class DelayedSH19SameDaySubmissionSupportEmailMapper {
             .withTo(config.getSupportEmailAddress())
             .withSubject(config.getSubject())
             .withDelayedSubmissions(model.getDelayedSubmissions())
+            .withThresholdInMinutes(model.getThresholdInMinutes())
             .build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSH19SameDaySubmissionSupportEmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSH19SameDaySubmissionSupportEmailMapper.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.efs.api.email.mapper;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.efs.api.email.config.DelayedSH19SameDaySubmissionSupportEmailConfig;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailData;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.EmailDocument;
+import uk.gov.companieshouse.efs.api.util.IdentifierGeneratable;
+import uk.gov.companieshouse.efs.api.util.TimestampGenerator;
+
+@Component
+public class DelayedSH19SameDaySubmissionSupportEmailMapper {
+    private DelayedSH19SameDaySubmissionSupportEmailConfig config;
+    private IdentifierGeneratable idGenerator;
+    private TimestampGenerator<LocalDateTime> timestampGenerator;
+
+    /**
+     * Constructor.
+     *
+     * @param config             dependency
+     * @param idGenerator        dependency
+     * @param timestampGenerator dependency
+     */
+    public DelayedSH19SameDaySubmissionSupportEmailMapper(
+        DelayedSH19SameDaySubmissionSupportEmailConfig config, IdentifierGeneratable idGenerator,
+        TimestampGenerator<LocalDateTime> timestampGenerator) {
+        this.config = config;
+        this.idGenerator = idGenerator;
+        this.timestampGenerator = timestampGenerator;
+    }
+
+    public EmailDocument<DelayedSubmissionSupportEmailData> map(
+        DelayedSubmissionSupportEmailModel model) {
+        return EmailDocument.<DelayedSubmissionSupportEmailData>builder()
+            .withTopic(config.getTopic())
+            .withMessageId(idGenerator.generateId())
+            .withRecipientEmailAddress(config.getSupportEmailAddress())
+            .withEmailTemplateAppId(config.getAppId())
+            .withEmailTemplateMessageType(config.getMessageType())
+            .withData(fromDelayedSubmissions(model))
+            .withCreatedAt(timestampGenerator.generateTimestamp()
+                .format(DateTimeFormatter.ofPattern(config.getDateFormat())))
+            .build();
+    }
+
+    private DelayedSubmissionSupportEmailData fromDelayedSubmissions(
+        DelayedSubmissionSupportEmailModel model) {
+        return DelayedSubmissionSupportEmailData.builder()
+            .withTo(config.getSupportEmailAddress())
+            .withSubject(config.getSubject())
+            .withDelayedSubmissions(model.getDelayedSubmissions())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSubmissionSupportEmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSubmissionSupportEmailMapper.java
@@ -48,6 +48,7 @@ public class DelayedSubmissionSupportEmailMapper {
                 .withTo(config.getSupportEmailAddress())
                 .withSubject(config.getSubject())
                 .withDelayedSubmissions(model.getDelayedSubmissions())
+                .withThresholdInMinutes(model.getThresholdInMinutes())
                 .build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/EmailMapperFactory.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/EmailMapperFactory.java
@@ -11,6 +11,7 @@ public class EmailMapperFactory {
     private InternalFailedConversionEmailMapper internalFailedConversionEmailMapper;
     private InternalSubmissionEmailMapper internalSubmissionEmailMapper;
     private DelayedSubmissionSupportEmailMapper delayedSubmissionSupportEmailMapper;
+    private DelayedSH19SameDaySubmissionSupportEmailMapper delayedSH19SameDaySubmissionSupportEmailMapper;
     private DelayedSubmissionBusinessEmailMapper delayedSubmissionBusinessEmailMapper;
     private PaymentReportEmailMapper paymentReportEmailMapper;
 
@@ -27,6 +28,7 @@ public class EmailMapperFactory {
         internalFailedConversionEmailMapper = builder.internalFailedConversionEmailMapper;
         internalSubmissionEmailMapper = builder.internalSubmissionEmailMapper;
         delayedSubmissionSupportEmailMapper = builder.delayedSubmissionSupportEmailMapper;
+        delayedSH19SameDaySubmissionSupportEmailMapper = builder.delayedSH19SameDaySubmissionSupportEmailMapper;
         delayedSubmissionBusinessEmailMapper = builder.delayedSubmissionBusinessEmailMapper;
         paymentReportEmailMapper = builder.paymentReportEmailMapper;
     }
@@ -45,6 +47,8 @@ public class EmailMapperFactory {
         builder.internalFailedConversionEmailMapper = copy.getInternalFailedConversionEmailMapper();
         builder.internalSubmissionEmailMapper = copy.getInternalSubmissionEmailMapper();
         builder.delayedSubmissionSupportEmailMapper = copy.getDelayedSubmissionSupportEmailMapper();
+        builder.delayedSH19SameDaySubmissionSupportEmailMapper =
+            copy.getDelayedSH19SameDaySubmissionSupportEmailMapper();
         builder.delayedSubmissionBusinessEmailMapper =
             copy.getDelayedSubmissionBusinessEmailMapper();
         builder.paymentReportEmailMapper = copy.getPaymentReportEmailMapper();
@@ -83,6 +87,10 @@ public class EmailMapperFactory {
         return delayedSubmissionSupportEmailMapper;
     }
 
+    public DelayedSH19SameDaySubmissionSupportEmailMapper getDelayedSH19SameDaySubmissionSupportEmailMapper() {
+        return delayedSH19SameDaySubmissionSupportEmailMapper;
+    }
+
     public DelayedSubmissionBusinessEmailMapper getDelayedSubmissionBusinessEmailMapper() {
         return delayedSubmissionBusinessEmailMapper;
     }
@@ -103,12 +111,14 @@ public class EmailMapperFactory {
         private InternalFailedConversionEmailMapper internalFailedConversionEmailMapper;
         private InternalSubmissionEmailMapper internalSubmissionEmailMapper;
         private DelayedSubmissionSupportEmailMapper delayedSubmissionSupportEmailMapper;
+        private DelayedSH19SameDaySubmissionSupportEmailMapper
+            delayedSH19SameDaySubmissionSupportEmailMapper;
         private DelayedSubmissionBusinessEmailMapper delayedSubmissionBusinessEmailMapper;
         private PaymentReportEmailMapper paymentReportEmailMapper;
 
         private Builder() {
         }
-
+        
         /**
          * Sets the {@code confirmationEmailMapper} and returns a reference to this Builder so 
          * that the methods can be chained together.
@@ -205,6 +215,18 @@ public class EmailMapperFactory {
         }
 
         /**
+         * Sets the {@code delayedSH19SubmissionSupportEmailMapper} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param delayedSH19SameDaySubmissionSupportEmailMapper the {@code delayedSubmissionSupportEmailMapper} to set
+         * @return a reference to this Builder
+         */
+        public Builder withDelayedSH19SameDaySubmissionSupportEmailMapper(
+            final DelayedSH19SameDaySubmissionSupportEmailMapper delayedSH19SameDaySubmissionSupportEmailMapper) {
+            this.delayedSH19SameDaySubmissionSupportEmailMapper = delayedSH19SameDaySubmissionSupportEmailMapper;
+            return this;
+        }
+
+        /**
          * Sets the {@code delayedSubmissionBusinessEmailMapper} and returns a reference to this Builder so that the methods can be chained together.
          *
          * @param delayedSubmissionBusinessEmailMapper the {@code delayedSubmissionBusinessEmailMapper} to set
@@ -241,6 +263,8 @@ public class EmailMapperFactory {
             checkNotNull(this.delayedSubmissionBusinessEmailMapper,
                 "'delayedSubmissionBusinessEmailMapper' must not be null");
             checkNotNull(this.delayedSubmissionSupportEmailMapper, "'delayedSubmissionSupportEmailMapper' must not be null");
+            checkNotNull(this.delayedSH19SameDaySubmissionSupportEmailMapper,
+                "'this.delayedSH19SameDaySubmissionSupportEmailMapper' must not be null");
             checkNotNull(this.internalAvFailedEmailMapper, "'internalAVFailedEmailMapper' must not be null");
             checkNotNull(this.internalFailedConversionEmailMapper, "'internalFailedConversionEmailMapper' must not be null");
             checkNotNull(this.internalSubmissionEmailMapper, "'internalSubmissionEmailMapper' must not be null");
@@ -277,7 +301,9 @@ public class EmailMapperFactory {
             && Objects.equals(getInternalSubmissionEmailMapper(),
             that.getInternalSubmissionEmailMapper()) && Objects.equals(
             getDelayedSubmissionSupportEmailMapper(), that.getDelayedSubmissionSupportEmailMapper())
-            && Objects.equals(getDelayedSubmissionBusinessEmailMapper(),
+            && Objects.equals(getDelayedSH19SameDaySubmissionSupportEmailMapper(),
+            that.getDelayedSH19SameDaySubmissionSupportEmailMapper()) && Objects.equals(
+            getDelayedSubmissionBusinessEmailMapper(),
             that.getDelayedSubmissionBusinessEmailMapper()) && Objects.equals(
             getPaymentReportEmailMapper(), that.getPaymentReportEmailMapper());
     }
@@ -287,7 +313,8 @@ public class EmailMapperFactory {
         return Objects.hash(getConfirmationEmailMapper(), getPaymentFailedEmailMapper(),
             getAcceptEmailMapper(), getRejectEmailMapper(), getInternalAvFailedEmailMapper(),
             getInternalFailedConversionEmailMapper(), getInternalSubmissionEmailMapper(),
-            getDelayedSubmissionSupportEmailMapper(), getDelayedSubmissionBusinessEmailMapper(),
-            getPaymentReportEmailMapper());
+            getDelayedSubmissionSupportEmailMapper(),
+            getDelayedSH19SameDaySubmissionSupportEmailMapper(),
+            getDelayedSubmissionBusinessEmailMapper(), getPaymentReportEmailMapper());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/InternalEmailMapperFactory.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/mapper/InternalEmailMapperFactory.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 public class InternalEmailMapperFactory {
     private final DelayedSubmissionBusinessEmailMapper delayedSubmissionBusinessMapper;
     private final DelayedSubmissionSupportEmailMapper delayedSubmissionSupportMapper;
+    private final DelayedSH19SameDaySubmissionSupportEmailMapper
+        delayedSH19SameDaySubmissionSupportEmailMapper;
     private final InternalAvFailedEmailMapper internalAvFailedMapper;
     private final InternalFailedConversionEmailMapper internalFailedConversionMapper;
     private final InternalSubmissionEmailMapper internalSubmissionMapper;
@@ -13,12 +15,15 @@ public class InternalEmailMapperFactory {
 
     public InternalEmailMapperFactory(final DelayedSubmissionBusinessEmailMapper delayedSubmissionBusinessMapper,
         final DelayedSubmissionSupportEmailMapper delayedSubmissionSupportMapper,
+        final DelayedSH19SameDaySubmissionSupportEmailMapper delayedSH19SameDaySubmissionSupportEmailMapper,
         final InternalAvFailedEmailMapper internalAvFailedMapper,
         final InternalFailedConversionEmailMapper internalFailedConversionMapper,
         final InternalSubmissionEmailMapper internalSubmissionMapper,
         final PaymentReportEmailMapper paymentReportMapper) {
         this.delayedSubmissionBusinessMapper = delayedSubmissionBusinessMapper;
         this.delayedSubmissionSupportMapper = delayedSubmissionSupportMapper;
+        this.delayedSH19SameDaySubmissionSupportEmailMapper =
+            delayedSH19SameDaySubmissionSupportEmailMapper;
         this.internalAvFailedMapper = internalAvFailedMapper;
         this.internalFailedConversionMapper = internalFailedConversionMapper;
         this.internalSubmissionMapper = internalSubmissionMapper;
@@ -31,6 +36,10 @@ public class InternalEmailMapperFactory {
 
     public DelayedSubmissionSupportEmailMapper getDelayedSubmissionSupportMapper() {
         return delayedSubmissionSupportMapper;
+    }
+
+    public DelayedSH19SameDaySubmissionSupportEmailMapper getDelayedSH19SameDaySubmissionSupportEmailMapper() {
+        return delayedSH19SameDaySubmissionSupportEmailMapper;
     }
 
     public InternalAvFailedEmailMapper getInternalAvFailedMapper() {

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessEmailModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessEmailModel.java
@@ -2,17 +2,22 @@ package uk.gov.companieshouse.efs.api.email.model;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class DelayedSubmissionBusinessEmailModel {
 
     private List<DelayedSubmissionBusinessModel> delayedSubmissions;
     private String emailAddress;
-    private int delayInHours;
+    private int delayInMinutes;
 
-    public DelayedSubmissionBusinessEmailModel(List<DelayedSubmissionBusinessModel> delayedSubmissions, String emailAddress, int delayInHours) {
+    public DelayedSubmissionBusinessEmailModel(List<DelayedSubmissionBusinessModel> delayedSubmissions, String emailAddress,
+        int delayInMinutes) {
         this.delayedSubmissions = delayedSubmissions;
         this.emailAddress = emailAddress;
-        this.delayInHours = delayInHours;
+        this.delayInMinutes = delayInMinutes;
     }
 
     public List<DelayedSubmissionBusinessModel> getDelayedSubmissions() {
@@ -32,15 +37,23 @@ public class DelayedSubmissionBusinessEmailModel {
     }
 
     public int getNumberOfDelayedSubmissions() {
-        return this.delayedSubmissions.size();
+        return Optional.ofNullable(delayedSubmissions).map(List::size).orElse(0);
+    }
+
+    public int getDelayInMinutes() {
+        return delayInMinutes;
+    }
+
+    public void setDelayInMinutes(final int delayInMinutes) {
+        this.delayInMinutes = delayInMinutes;
     }
 
     public int getDelayInHours() {
-        return delayInHours;
+        return (int) TimeUnit.MINUTES.toHours(delayInMinutes);
     }
 
     public void setDelayInHours(int delayInHours) {
-        this.delayInHours = delayInHours;
+        this.delayInMinutes = (int) TimeUnit.HOURS.toMinutes(delayInHours);
     }
 
     @Override
@@ -52,13 +65,19 @@ public class DelayedSubmissionBusinessEmailModel {
             return false;
         }
         final DelayedSubmissionBusinessEmailModel that = (DelayedSubmissionBusinessEmailModel) o;
-        return getDelayInHours() == that.getDelayInHours() && Objects
-            .equals(getDelayedSubmissions(), that.getDelayedSubmissions()) && Objects
-                   .equals(getEmailAddress(), that.getEmailAddress());
+        return getDelayInMinutes() == that.getDelayInMinutes() && Objects.equals(
+            getDelayedSubmissions(), that.getDelayedSubmissions()) && Objects.equals(
+            getEmailAddress(), that.getEmailAddress());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getDelayedSubmissions(), getEmailAddress(), getDelayInHours());
+        return Objects.hash(getDelayedSubmissions(), getEmailAddress(), getDelayInMinutes());
     }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessModel.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.efs.api.email.model;
 
 import java.util.Objects;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class DelayedSubmissionBusinessModel {
 
@@ -89,4 +91,10 @@ public class DelayedSubmissionBusinessModel {
             .hash(getConfirmationReference(), getCompanyNumber(), getFormType(), getEmail(),
                 getSubmissionDate());
     }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailData.java
@@ -2,16 +2,21 @@ package uk.gov.companieshouse.efs.api.email.model;
 
 import java.util.List;
 import java.util.Objects;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class DelayedSubmissionSupportEmailData {
     private String to;
     private String subject;
     private List<DelayedSubmissionSupportModel> delayedSubmissions;
+    private int thresholdInMinutes;
 
-    public DelayedSubmissionSupportEmailData(String to, String subject, List<DelayedSubmissionSupportModel> delayedSubmissions) {
+    public DelayedSubmissionSupportEmailData(String to, String subject,
+        List<DelayedSubmissionSupportModel> delayedSubmissions, final int thresholdInMinutes) {
         this.to = to;
         this.subject = subject;
         this.delayedSubmissions = delayedSubmissions;
+        this.thresholdInMinutes = thresholdInMinutes;
     }
 
     public String getTo() {
@@ -38,6 +43,14 @@ public class DelayedSubmissionSupportEmailData {
         this.delayedSubmissions = delayedSubmissions;
     }
 
+    public int getThresholdInMinutes() {
+        return thresholdInMinutes;
+    }
+
+    public void setThresholdInMinutes(final int thresholdInMinutes) {
+        this.thresholdInMinutes = thresholdInMinutes;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -47,14 +60,20 @@ public class DelayedSubmissionSupportEmailData {
             return false;
         }
         final DelayedSubmissionSupportEmailData that = (DelayedSubmissionSupportEmailData) o;
-        return Objects.equals(getTo(), that.getTo()) && Objects
-            .equals(getSubject(), that.getSubject()) && Objects
-                   .equals(getDelayedSubmissions(), that.getDelayedSubmissions());
+        return getThresholdInMinutes() == that.getThresholdInMinutes() && Objects.equals(getTo(),
+            that.getTo()) && Objects.equals(getSubject(), that.getSubject()) && Objects.equals(
+            getDelayedSubmissions(), that.getDelayedSubmissions());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getTo(), getSubject(), getDelayedSubmissions());
+        return Objects.hash(getTo(), getSubject(), getDelayedSubmissions(),
+            getThresholdInMinutes());
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }
 
     public static Builder builder() {
@@ -65,6 +84,7 @@ public class DelayedSubmissionSupportEmailData {
         private String to;
         private String subject;
         private List<DelayedSubmissionSupportModel> delayedSubmissions;
+        private int thresholdInMinutes;
 
 
         public Builder withTo(String to) {
@@ -81,9 +101,14 @@ public class DelayedSubmissionSupportEmailData {
             this.delayedSubmissions = delayedSubmissions;
             return this;
         }
+        
+        public Builder withThresholdInMinutes(int thresholdInMinutes) {
+            this.thresholdInMinutes = thresholdInMinutes;
+            return this;
+        }
 
         public DelayedSubmissionSupportEmailData build() {
-            return new DelayedSubmissionSupportEmailData(to, subject, delayedSubmissions);
+            return new DelayedSubmissionSupportEmailData(to, subject, delayedSubmissions, thresholdInMinutes);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModel.java
@@ -2,6 +2,9 @@ package uk.gov.companieshouse.efs.api.email.model;
 
 import java.util.List;
 import java.util.Objects;
+import org.apache.commons.lang3.builder.RecursiveToStringStyle;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class DelayedSubmissionSupportEmailModel {
     private List<DelayedSubmissionSupportModel> delayedSubmissions;
@@ -37,5 +40,10 @@ public class DelayedSubmissionSupportEmailModel {
     @Override
     public int hashCode() {
         return Objects.hash(getDelayedSubmissions());
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModel.java
@@ -2,15 +2,17 @@ package uk.gov.companieshouse.efs.api.email.model;
 
 import java.util.List;
 import java.util.Objects;
-import org.apache.commons.lang3.builder.RecursiveToStringStyle;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class DelayedSubmissionSupportEmailModel {
     private List<DelayedSubmissionSupportModel> delayedSubmissions;
+    private int thresholdInMinutes;
 
-    public DelayedSubmissionSupportEmailModel(List<DelayedSubmissionSupportModel> delayedSubmissions) {
+    public DelayedSubmissionSupportEmailModel(
+        List<DelayedSubmissionSupportModel> delayedSubmissions, final int thresholdInMinutes) {
         this.delayedSubmissions = delayedSubmissions;
+        this.thresholdInMinutes = thresholdInMinutes;
     }
 
     public List<DelayedSubmissionSupportModel> getDelayedSubmissions() {
@@ -25,6 +27,14 @@ public class DelayedSubmissionSupportEmailModel {
         return delayedSubmissions.size();
     }
 
+    public int getThresholdInMinutes() {
+        return thresholdInMinutes;
+    }
+
+    public void setThresholdInMinutes(final int thresholdInMinutes) {
+        this.thresholdInMinutes = thresholdInMinutes;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -34,12 +44,13 @@ public class DelayedSubmissionSupportEmailModel {
             return false;
         }
         final DelayedSubmissionSupportEmailModel that = (DelayedSubmissionSupportEmailModel) o;
-        return Objects.equals(getDelayedSubmissions(), that.getDelayedSubmissions());
+        return getThresholdInMinutes() == that.getThresholdInMinutes() && Objects.equals(
+            getDelayedSubmissions(), that.getDelayedSubmissions());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getDelayedSubmissions());
+        return Objects.hash(getDelayedSubmissions(), getThresholdInMinutes());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModel.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.efs.api.email.model;
 
 import java.util.Objects;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class DelayedSubmissionSupportModel {
     private String submissionId;
@@ -56,4 +58,10 @@ public class DelayedSubmissionSupportModel {
     public int hashCode() {
         return Objects.hash(getSubmissionId(), getConfirmationReference(), getSubmittedAt());
     }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModel.java
@@ -8,11 +8,16 @@ public class DelayedSubmissionSupportModel {
     private String submissionId;
     private String confirmationReference;
     private String submittedAt;
+    private String customerEmail;
+    private String companyNumber;
 
-    public DelayedSubmissionSupportModel(String submissionId, String confirmationReference, String submittedAt) {
+    public DelayedSubmissionSupportModel(String submissionId, String confirmationReference,
+        String submittedAt, final String customerEmail, final String companyNumber) {
         this.submissionId = submissionId;
         this.confirmationReference = confirmationReference;
         this.submittedAt = submittedAt;
+        this.customerEmail = customerEmail;
+        this.companyNumber = companyNumber;
     }
 
     public String getSubmissionId() {
@@ -39,9 +44,24 @@ public class DelayedSubmissionSupportModel {
         this.submittedAt = submittedAt;
     }
 
+    public String getCustomerEmail() {
+        return customerEmail;
+    }
+
+    public void setCustomerEmail(final String customerEmail) {
+        this.customerEmail = customerEmail;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(final String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
     @Override
     public boolean equals(final Object o) {
-
         if (this == o) {
             return true;
         }
@@ -49,14 +69,16 @@ public class DelayedSubmissionSupportModel {
             return false;
         }
         final DelayedSubmissionSupportModel that = (DelayedSubmissionSupportModel) o;
-        return Objects.equals(getSubmissionId(), that.getSubmissionId()) && Objects
-            .equals(getConfirmationReference(), that.getConfirmationReference()) && Objects
-                   .equals(getSubmittedAt(), that.getSubmittedAt());
+        return Objects.equals(getSubmissionId(), that.getSubmissionId()) && Objects.equals(
+            getConfirmationReference(), that.getConfirmationReference()) && Objects.equals(
+            getSubmittedAt(), that.getSubmittedAt()) && Objects.equals(getCustomerEmail(),
+            that.getCustomerEmail()) && Objects.equals(getCompanyNumber(), that.getCompanyNumber());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getSubmissionId(), getConfirmationReference(), getSubmittedAt());
+        return Objects.hash(getSubmissionId(), getConfirmationReference(), getSubmittedAt(),
+            getCustomerEmail(), getCompanyNumber());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/controller/HandleDelayedSubmissionsController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/controller/HandleDelayedSubmissionsController.java
@@ -1,9 +1,12 @@
 package uk.gov.companieshouse.efs.api.events.controller;
 
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.efs.api.events.service.DelayedSubmissionHandlerContext;
 import uk.gov.companieshouse.efs.api.events.service.EventService;
 
 @RestController
@@ -14,10 +17,13 @@ public class HandleDelayedSubmissionsController {
     public HandleDelayedSubmissionsController(EventService eventService) {
         this.eventService = eventService;
     }
-    
+
     @PostMapping(value = "/efs-submission-api/events/handle-delayed-submissions")
-    public ResponseEntity<Void> handleDelayedSubmissions() {
-        this.eventService.handleDelayedSubmissions();
+    public ResponseEntity<Void> handleDelayedSubmissions(
+        @RequestParam(value = "service", required = false)
+            DelayedSubmissionHandlerContext.ServiceLevel serviceLevel) {
+        this.eventService.handleDelayedSubmissions(
+            Optional.ofNullable(serviceLevel).orElse(DelayedSubmissionHandlerContext.ServiceLevel.STANDARD));
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerContext.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerContext.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DelayedSubmissionHandlerContext {
+    private Map<ServiceLevel, DelayedSubmissionHandlerStrategy> strategyImplementations;
+
+    public enum ServiceLevel {
+        STANDARD, SAMEDAY
+    }
+
+    @Autowired
+    public DelayedSubmissionHandlerContext(
+        final Set<DelayedSubmissionHandlerStrategy> implementationSet) {
+        implementationSet.forEach(s -> System.out.println(s.getServiceLevel() + "," + s));
+        this.strategyImplementations = implementationSet.stream()
+            .collect(Collectors.toMap(DelayedSubmissionHandlerStrategy::getServiceLevel,
+                Function.identity()));
+    }
+
+    public DelayedSubmissionHandlerStrategy getStrategy(final ServiceLevel serviceLevel) {
+        return strategyImplementations.get(serviceLevel);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerStrategy.java
@@ -1,0 +1,13 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import uk.gov.companieshouse.efs.api.submissions.model.Submission;
+
+public interface DelayedSubmissionHandlerStrategy {
+    DelayedSubmissionHandlerContext.ServiceLevel getServiceLevel();
+    
+    List<Submission> findDelayedSubmissions(LocalDateTime handledAt);
+
+    void buildAndSendEmails(List<Submission> submissions, LocalDateTime handledAt);
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/EventService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/EventService.java
@@ -15,5 +15,5 @@ public interface EventService {
 
     void updateConversionFileStatus(String submissionId, String fileId, FileConversionStatusApi fileConversionStatusApi);
 
-    void handleDelayedSubmissions();
+    void handleDelayedSubmissions(final DelayedSubmissionHandlerContext.ServiceLevel serviceLevel);
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandler.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandler.java
@@ -1,0 +1,66 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionStatus;
+import uk.gov.companieshouse.efs.api.email.EmailService;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportModel;
+import uk.gov.companieshouse.efs.api.submissions.model.Submission;
+import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository;
+
+@Component("sameDayServiceDelayedSubmissionHandler")
+public class SameDayServiceDelayedHandler implements DelayedSubmissionHandlerStrategy {
+    static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
+    static final EnumSet<SubmissionStatus> DELAYED_STATUSES =
+        EnumSet.of(SubmissionStatus.PROCESSING, SubmissionStatus.READY_TO_SUBMIT);
+
+    private SubmissionRepository repository;
+    private EmailService emailService;
+    private int supportDelayInMinutes;
+
+    @Autowired
+    public SameDayServiceDelayedHandler(final SubmissionRepository repository,
+        final EmailService emailService,
+        @Value("${submission.sameday.support.minutes}") final int supportDelayInMinutes) {
+        this.repository = repository;
+        this.emailService = emailService;
+        this.supportDelayInMinutes = supportDelayInMinutes;
+    }
+
+    @Override
+    public final DelayedSubmissionHandlerContext.ServiceLevel getServiceLevel() {
+        return DelayedSubmissionHandlerContext.ServiceLevel.SAMEDAY;
+    }
+
+    @Override
+    public List<Submission> findDelayedSubmissions(final LocalDateTime handledAt) {
+        LocalDateTime supportDelay = handledAt.minusMinutes(supportDelayInMinutes);
+
+        return repository.findDelayedSameDaySubmissions(DELAYED_STATUSES, supportDelay);
+    }
+
+    @Override
+    public void buildAndSendEmails(final List<Submission> submissions,
+        final LocalDateTime handledAt) {
+        List<DelayedSubmissionSupportModel> supportModels = submissions.stream()
+            .map(submission -> new DelayedSubmissionSupportModel(submission.getId(),
+                submission.getConfirmationReference(),
+                Optional.ofNullable(submission.getSubmittedAt())
+                    .orElseGet(submission::getCreatedAt)
+                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))
+            .collect(Collectors.toList());
+
+        if (!supportModels.isEmpty()) {
+            emailService.sendDelayedSubmissionSupportEmail(
+                new DelayedSubmissionSupportEmailModel(supportModels));
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandler.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.events.service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
 import java.util.List;
@@ -18,7 +19,8 @@ import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository
 
 @Component("sameDayServiceDelayedSubmissionHandler")
 public class SameDayServiceDelayedHandler implements DelayedSubmissionHandlerStrategy {
-    static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
+    static final ZoneId UK_ZONE = ZoneId.of("Europe/London");
+    static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm z";
     static final EnumSet<SubmissionStatus> DELAYED_STATUSES =
         EnumSet.of(SubmissionStatus.PROCESSING, SubmissionStatus.READY_TO_SUBMIT);
 
@@ -55,12 +57,14 @@ public class SameDayServiceDelayedHandler implements DelayedSubmissionHandlerStr
                 submission.getConfirmationReference(),
                 Optional.ofNullable(submission.getSubmittedAt())
                     .orElseGet(submission::getCreatedAt)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))
+                    .atZone(UK_ZONE)
+                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                submission.getPresenter().getEmail(), submission.getCompany().getCompanyNumber()))
             .collect(Collectors.toList());
 
         if (!supportModels.isEmpty()) {
-            emailService.sendDelayedSubmissionSupportEmail(
-                new DelayedSubmissionSupportEmailModel(supportModels));
+            emailService.sendDelayedSH19SubmissionSupportEmail(
+                new DelayedSubmissionSupportEmailModel(supportModels, supportDelayInMinutes));
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandler.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandler.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.efs.api.events.service;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
 import java.util.List;
@@ -19,8 +18,7 @@ import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository
 
 @Component("sameDayServiceDelayedSubmissionHandler")
 public class SameDayServiceDelayedHandler implements DelayedSubmissionHandlerStrategy {
-    static final ZoneId UK_ZONE = ZoneId.of("Europe/London");
-    static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm z";
+    static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm";
     static final EnumSet<SubmissionStatus> DELAYED_STATUSES =
         EnumSet.of(SubmissionStatus.PROCESSING, SubmissionStatus.READY_TO_SUBMIT);
 
@@ -57,7 +55,6 @@ public class SameDayServiceDelayedHandler implements DelayedSubmissionHandlerStr
                 submission.getConfirmationReference(),
                 Optional.ofNullable(submission.getSubmittedAt())
                     .orElseGet(submission::getCreatedAt)
-                    .atZone(UK_ZONE)
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                 submission.getPresenter().getEmail(), submission.getCompany().getCompanyNumber()))
             .collect(Collectors.toList());

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandler.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandler.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.efs.api.events.service;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +22,6 @@ import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository
 
 @Component("standardServiceDelayedSubmissionHandler")
 public class StandardServiceDelayedHandler implements DelayedSubmissionHandlerStrategy {
-    static final ZoneId UK_ZONE = ZoneId.of("Europe/London");
     static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm z";
     static final String SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT = "dd MMMM yyyy";
 
@@ -67,7 +65,6 @@ public class StandardServiceDelayedHandler implements DelayedSubmissionHandlerSt
                 submission.getConfirmationReference(),
                 Optional.ofNullable(submission.getSubmittedAt())
                     .orElseGet(submission::getCreatedAt)
-                    .atZone(UK_ZONE)
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                 submission.getPresenter().getEmail(), submission.getCompany().getCompanyNumber()))
             .collect(Collectors.toList());
@@ -86,7 +83,6 @@ public class StandardServiceDelayedHandler implements DelayedSubmissionHandlerSt
                         submission.getPresenter().getEmail(),
                         Optional.ofNullable(submission.getSubmittedAt())
                             .orElseGet(submission::getCreatedAt)
-                            .atZone(UK_ZONE)
                             .format(DateTimeFormatter.ofPattern(
                                 SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT))))
                     .collect(Collectors.groupingBy(

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandler.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandler.java
@@ -1,0 +1,93 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionStatus;
+import uk.gov.companieshouse.efs.api.email.EmailService;
+import uk.gov.companieshouse.efs.api.email.FormCategoryToEmailAddressService;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionBusinessEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionBusinessModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportModel;
+import uk.gov.companieshouse.efs.api.submissions.model.Submission;
+import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository;
+
+@Component("standardServiceDelayedSubmissionHandler")
+public class StandardServiceDelayedHandler implements DelayedSubmissionHandlerStrategy {
+    static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
+    static final String SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT = "dd MMMM yyyy";
+
+    private SubmissionRepository repository;
+    private EmailService emailService;
+    private FormCategoryToEmailAddressService formCategoryToEmailAddressService;
+    private int supportDelayInHours;
+    private int businessDelayInHours;
+
+    @Autowired
+    public StandardServiceDelayedHandler(final SubmissionRepository repository,
+        final EmailService emailService,
+        final FormCategoryToEmailAddressService formCategoryToEmailAddressService,
+        @Value("${submission.processing.support.hours}") final int supportDelayInHours,
+        @Value("${submission.processing.business.hours}") final int businessDelayInHours) {
+        this.repository = repository;
+        this.emailService = emailService;
+        this.formCategoryToEmailAddressService = formCategoryToEmailAddressService;
+        this.supportDelayInHours = supportDelayInHours;
+        this.businessDelayInHours = businessDelayInHours;
+    }
+
+    @Override
+    public final DelayedSubmissionHandlerContext.ServiceLevel getServiceLevel() {
+        return DelayedSubmissionHandlerContext.ServiceLevel.STANDARD;
+    }
+
+    @Override
+    public List<Submission> findDelayedSubmissions(final LocalDateTime handledAt) {
+        LocalDateTime supportDelay = handledAt.minusHours(supportDelayInHours);
+
+        return repository.findDelayedSubmissions(SubmissionStatus.PROCESSING, supportDelay);
+    }
+
+    @Override
+    public void buildAndSendEmails(final List<Submission> submissions,
+        final LocalDateTime handledAt) {
+        LocalDateTime businessDelay = handledAt.minusHours(businessDelayInHours);
+        List<DelayedSubmissionSupportModel> supportModels = submissions.stream()
+            .map(submission -> new DelayedSubmissionSupportModel(submission.getId(),
+                submission.getConfirmationReference(),
+                Optional.ofNullable(submission.getSubmittedAt())
+                    .orElseGet(submission::getCreatedAt)
+                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))
+            .collect(Collectors.toList());
+
+        if (!supportModels.isEmpty()) {
+            emailService.sendDelayedSubmissionSupportEmail(
+                new DelayedSubmissionSupportEmailModel(supportModels));
+            Map<String, List<DelayedSubmissionBusinessModel>> delayedSubmissionBusinessModels =
+                submissions.stream()
+                    .filter(submission -> submission.getLastModifiedAt().isBefore(businessDelay))
+                    .map(submission -> new DelayedSubmissionBusinessModel(
+                        submission.getConfirmationReference(),
+                        submission.getCompany().getCompanyNumber(),
+                        submission.getFormDetails().getFormType(),
+                        submission.getPresenter().getEmail(),
+                        Optional.ofNullable(submission.getSubmittedAt())
+                            .orElseGet(submission::getCreatedAt)
+                            .format(DateTimeFormatter.ofPattern(
+                                SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT))))
+                    .collect(Collectors.groupingBy(
+                        delayedSubmissionModel -> formCategoryToEmailAddressService.getEmailAddressForFormCategory(
+                            delayedSubmissionModel.getFormType())));
+            delayedSubmissionBusinessModels.forEach(
+                (key, value) -> emailService.sendDelayedSubmissionBusinessEmail(
+                    new DelayedSubmissionBusinessEmailModel(value, key, businessDelayInHours)));
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandler.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.events.service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,9 @@ import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository
 public class StandardServiceDelayedHandler implements DelayedSubmissionHandlerStrategy {
     static final String SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT = "dd/MM/yyyy HH:mm z";
     static final String SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT = "dd MMMM yyyy";
+    static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+    private static final DateTimeFormatter FORMATTER =
+        DateTimeFormatter.ofPattern(SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT).withZone(UTC_ZONE);
 
     private SubmissionRepository repository;
     private EmailService emailService;
@@ -65,7 +69,7 @@ public class StandardServiceDelayedHandler implements DelayedSubmissionHandlerSt
                 submission.getConfirmationReference(),
                 Optional.ofNullable(submission.getSubmittedAt())
                     .orElseGet(submission::getCreatedAt)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    .format(FORMATTER),
                 submission.getPresenter().getEmail(), submission.getCompany().getCompanyNumber()))
             .collect(Collectors.toList());
 
@@ -83,8 +87,7 @@ public class StandardServiceDelayedHandler implements DelayedSubmissionHandlerSt
                         submission.getPresenter().getEmail(),
                         Optional.ofNullable(submission.getSubmittedAt())
                             .orElseGet(submission::getCreatedAt)
-                            .format(DateTimeFormatter.ofPattern(
-                                SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT))))
+                            .format(FORMATTER)))
                     .collect(Collectors.groupingBy(
                         delayedSubmissionModel -> formCategoryToEmailAddressService.getEmailAddressForFormCategory(
                             delayedSubmissionModel.getFormType())));

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepository.java
@@ -28,6 +28,8 @@ public interface SubmissionRepository {
 
     List<Submission> findDelayedSubmissions(SubmissionStatus status, LocalDateTime before);
 
+    List<Submission> findDelayedSameDaySubmissions(Collection<SubmissionStatus> statuses, LocalDateTime submittedBefore);
+
     /**
      * Find paid submissions having any of the given statuses and submit date between startDate and endDate.
      *

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -34,6 +35,8 @@ public class SubmissionRepositoryImpl implements SubmissionRepository {
     private static final String ID = "_id";
     private static final String STATUS = "status";
     private static final String BARCODE = "form.barcode";
+    private static final String FORM_TYPE = "form.form_type";
+    private static final String SAMEDAY_REGEX = "SAMEDAY$";
     private static final String LAST_MODIFIED_AT = "last_modified_at";
     private static final String SUBMITTED_AT = "submitted_at";
     private static final String FEE_ON_SUBMISSION = "fee_on_submission";
@@ -111,12 +114,35 @@ public class SubmissionRepositoryImpl implements SubmissionRepository {
 
     @Override
     public List<Submission> findDelayedSubmissions(SubmissionStatus status, LocalDateTime before) {
-        LOGGER.debug(String.format("Fetching submissions with status: [%s] and before [%s]", status, before.toString()));
-        List<Submission> submissions = template
-            .find(Query.query(Criteria.where(STATUS).is(status).and(LAST_MODIFIED_AT).lte(before)), Submission.class,
-                SUBMISSIONS_COLLECTION);
-        LOGGER.debug(String.format("Found [%d] submissions with status: [%s] and before [%s]", submissions.size(), status,
-                before.toString()));
+        LOGGER.debug(
+            String.format("Fetching submissions with status: [%s] last modified before [%s]",
+                status, before.toString()));
+        List<Submission> submissions = template.find(Query.query(Criteria.where(STATUS)
+            .is(status)
+            .and(LAST_MODIFIED_AT)
+            .lte(before)
+            .not()
+            .and(FORM_TYPE)
+            .regex(SAMEDAY_REGEX)), Submission.class, SUBMISSIONS_COLLECTION);
+        LOGGER.debug(
+            String.format("Found [%d] submissions with status: [%s] last modified before [%s]",
+                submissions.size(), status, before));
+        return submissions;
+    }
+
+    @Override
+    public List<Submission> findDelayedSameDaySubmissions(Collection<SubmissionStatus> statuses, LocalDateTime submittedBefore) {
+        final String statusesString = Arrays.toString(statuses.toArray());
+        LOGGER.debug(String.format("Fetching sameday submissions with statuses: %s submitted before [%s]",
+            statusesString, submittedBefore));
+        List<Submission> submissions = template.find(Query.query(Criteria.where(STATUS)
+            .in(statuses)
+            .and(SUBMITTED_AT)
+            .lte(submittedBefore)
+            .and(FORM_TYPE)
+            .regex(SAMEDAY_REGEX)), Submission.class, SUBMISSIONS_COLLECTION);
+        LOGGER.debug(String.format("Found [%d] sameday submissions with statuses: %s submitted before [%s]",
+            submissions.size(), statusesString, submittedBefore));
         return submissions;
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
@@ -120,9 +120,8 @@ public class SubmissionRepositoryImpl implements SubmissionRepository {
             .is(status)
             .and(LAST_MODIFIED_AT)
             .lte(before)
-            .not()
             .and(FORM_TYPE)
-            .is("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
+            .ne("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
         LOGGER.debug(
             String.format("Found [%d] submissions with status: [%s] last modified before [%s]",
                 submissions.size(), status, before));

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImpl.java
@@ -36,7 +36,6 @@ public class SubmissionRepositoryImpl implements SubmissionRepository {
     private static final String STATUS = "status";
     private static final String BARCODE = "form.barcode";
     private static final String FORM_TYPE = "form.form_type";
-    private static final String SAMEDAY_REGEX = "SAMEDAY$";
     private static final String LAST_MODIFIED_AT = "last_modified_at";
     private static final String SUBMITTED_AT = "submitted_at";
     private static final String FEE_ON_SUBMISSION = "fee_on_submission";
@@ -123,7 +122,7 @@ public class SubmissionRepositoryImpl implements SubmissionRepository {
             .lte(before)
             .not()
             .and(FORM_TYPE)
-            .regex(SAMEDAY_REGEX)), Submission.class, SUBMISSIONS_COLLECTION);
+            .is("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
         LOGGER.debug(
             String.format("Found [%d] submissions with status: [%s] last modified before [%s]",
                 submissions.size(), status, before));
@@ -140,7 +139,7 @@ public class SubmissionRepositoryImpl implements SubmissionRepository {
             .and(SUBMITTED_AT)
             .lte(submittedBefore)
             .and(FORM_TYPE)
-            .regex(SAMEDAY_REGEX)), Submission.class, SUBMISSIONS_COLLECTION);
+            .is("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
         LOGGER.debug(String.format("Found [%d] sameday submissions with statuses: %s submitted before [%s]",
             submissions.size(), statusesString, submittedBefore));
         return submissions;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,7 @@ max.queue.messages=${EFS_MAX_QUEUE_MESSAGES}
 message.partition.size=${EFS_MESSAGE_PARTITION_SIZE}
 submission.processing.support.hours=${EFS_SUBMISSION_PROCESSING_SUPPORT_HOURS}
 submission.processing.business.hours=${EFS_SUBMISSION_PROCESSING_BUSINESS_HOURS}
+submission.sameday.support.minutes=${EFS_SUBMISSION_PROCESSING_SAMEDAY_SUPPORT_MINUTES}
 
 file.transfer.api.key=${FILE_TRANSFER_API_KEY}
 file.transfer.api.url=${FILE_TRANSFER_API_URL}

--- a/src/main/resources/delayed.sh19.sameday.submission.support.mail.properties
+++ b/src/main/resources/delayed.sh19.sameday.submission.support.mail.properties
@@ -1,0 +1,6 @@
+delayed.sh19.sameday.submission.support.mail.topic=email-send
+delayed.sh19.sameday.submission.support.mail.messageType=efs_submission_delayed_sh19_sameday
+delayed.sh19.sameday.submission.support.mail.appId=efs-submission-api.efs_submission_delayed_sh19_sameday
+delayed.sh19.sameday.submission.support.mail.subject=EFS submission delay alert: Same day SH19
+delayed.sh19.sameday.submission.support.mail.dateFormat=dd MMMM yyyy
+delayed.sh19.sameday.submission.support.mail.supportEmailAddress=${EFS_DELAYED_SUBMISSIONS_SUPPORT_EMAIL}

--- a/src/main/resources/delayed.submission.support.mail.properties
+++ b/src/main/resources/delayed.submission.support.mail.properties
@@ -4,3 +4,10 @@ delayed.submission.support.mail.appId=efs-submission-api.efs_submission_delayed_
 delayed.submission.support.mail.subject=EFS Submission Delayed
 delayed.submission.support.mail.dateFormat=dd MMMM yyyy
 delayed.submission.support.mail.supportEmailAddress=${EFS_DELAYED_SUBMISSIONS_SUPPORT_EMAIL}
+
+delayed.sh19_sameday.submission.support.mail.topic=email-send
+delayed.sh19_sameday.submission.support.mail.messageType=efs_submission_delayed_submission_support
+delayed.sh19_sameday.submission.support.mail.appId=efs-submission-api.efs_submission_delayed_submission_support
+delayed.sh19_sameday.submission.support.mail.subject=EFS Submission Delayed - SH19 Same Day
+delayed.sh19_sameday.submission.support.mail.dateFormat=dd MMMM yyyy
+delayed.sh19_sameday.submission.support.mail.supportEmailAddress=${EFS_DELAYED_SUBMISSIONS_SUPPORT_EMAIL}

--- a/src/main/resources/delayed.submission.support.mail.properties
+++ b/src/main/resources/delayed.submission.support.mail.properties
@@ -4,10 +4,3 @@ delayed.submission.support.mail.appId=efs-submission-api.efs_submission_delayed_
 delayed.submission.support.mail.subject=EFS Submission Delayed
 delayed.submission.support.mail.dateFormat=dd MMMM yyyy
 delayed.submission.support.mail.supportEmailAddress=${EFS_DELAYED_SUBMISSIONS_SUPPORT_EMAIL}
-
-delayed.sh19_sameday.submission.support.mail.topic=email-send
-delayed.sh19_sameday.submission.support.mail.messageType=efs_submission_delayed_submission_support
-delayed.sh19_sameday.submission.support.mail.appId=efs-submission-api.efs_submission_delayed_submission_support
-delayed.sh19_sameday.submission.support.mail.subject=EFS Submission Delayed - SH19 Same Day
-delayed.sh19_sameday.submission.support.mail.dateFormat=dd MMMM yyyy
-delayed.sh19_sameday.submission.support.mail.supportEmailAddress=${EFS_DELAYED_SUBMISSIONS_SUPPORT_EMAIL}

--- a/src/test/java/uk/gov/companieshouse/efs/api/config/ConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/config/ConfigTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import uk.gov.companieshouse.efs.api.email.mapper.DelayedSH19SameDaySubmissionSupportEmailMapper;
 import uk.gov.companieshouse.efs.api.email.mapper.DelayedSubmissionBusinessEmailMapper;
 import uk.gov.companieshouse.efs.api.email.mapper.DelayedSubmissionSupportEmailMapper;
 import uk.gov.companieshouse.efs.api.email.mapper.EmailMapperFactory;
@@ -73,6 +74,8 @@ class ConfigTest {
             new DelayedSubmissionBusinessEmailMapper(null, null, null);
         final DelayedSubmissionSupportEmailMapper delayedSubmissionSupportMapper =
             new DelayedSubmissionSupportEmailMapper(null, null, null);
+        final DelayedSH19SameDaySubmissionSupportEmailMapper delayedSH19SameDaySubmissionSupportEmailMapper =
+            new DelayedSH19SameDaySubmissionSupportEmailMapper(null, null, null);
         final InternalAvFailedEmailMapper internalAvFailedMapper =
             new InternalAvFailedEmailMapper(null, null, null, null);
         final InternalFailedConversionEmailMapper internalFailedConversionMapper =
@@ -82,7 +85,8 @@ class ConfigTest {
         final PaymentReportEmailMapper paymentReportMapper = new PaymentReportEmailMapper(null, null, null);
         final InternalEmailMapperFactory internalMapperFactory =
             new InternalEmailMapperFactory(delayedSubmissionBusinessMapper,
-                delayedSubmissionSupportMapper, internalAvFailedMapper,
+                delayedSubmissionSupportMapper, delayedSH19SameDaySubmissionSupportEmailMapper,
+                internalAvFailedMapper,
                 internalFailedConversionMapper, internalSubmissionMapper,
                 paymentReportMapper);
 
@@ -95,6 +99,8 @@ class ConfigTest {
         assertThat(mapperFactory.getPaymentFailedEmailMapper(), isA(ExternalNotificationEmailMapper.class));
         assertThat(mapperFactory.getRejectEmailMapper(), isA(ExternalRejectEmailMapper.class));
         assertThat(mapperFactory.getDelayedSubmissionBusinessEmailMapper(), isA(DelayedSubmissionBusinessEmailMapper.class));
+        assertThat(mapperFactory.getDelayedSH19SameDaySubmissionSupportEmailMapper(),
+            isA(DelayedSH19SameDaySubmissionSupportEmailMapper.class));
         assertThat(mapperFactory.getDelayedSubmissionSupportEmailMapper(), isA(DelayedSubmissionSupportEmailMapper.class));
         assertThat(mapperFactory.getInternalAvFailedEmailMapper(), isA(InternalAvFailedEmailMapper.class));
         assertThat(mapperFactory.getInternalFailedConversionEmailMapper(), isA(InternalFailedConversionEmailMapper.class));

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfigTest.java
@@ -20,6 +20,36 @@ class DelayedSH19SameDaySubmissionSupportEmailConfigTest {
     }
 
     @Test
+    void setGetAppId() {
+        testConfig.setAppId("expected");
+        assertThat(testConfig.getAppId(), is("expected"));
+    }
+
+    @Test
+    void setGetSubject() {
+        testConfig.setSubject("expected");
+        assertThat(testConfig.getSubject(), is("expected"));
+    }
+
+    @Test
+    void setGetTopic() {
+        testConfig.setTopic("expected");
+        assertThat(testConfig.getTopic(), is("expected"));
+    }
+
+    @Test
+    void setGetMessageType() {
+        testConfig.setMessageType("expected");
+        assertThat(testConfig.getMessageType(), is("expected"));
+    }
+
+    @Test
+    void setDateFormat() {
+        testConfig.setDateFormat("expected");
+        assertThat(testConfig.getDateFormat(), is("expected"));
+    }
+
+    @Test
     void setGetSupportEmailAddress() {
         testConfig.setSupportEmailAddress("email");
         assertThat(testConfig.getSupportEmailAddress(), is("email"));
@@ -32,4 +62,5 @@ class DelayedSH19SameDaySubmissionSupportEmailConfigTest {
             .suppress(Warning.NONFINAL_FIELDS)
             .verify();
     }
+
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/config/DelayedSH19SameDaySubmissionSupportEmailConfigTest.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.efs.api.email.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSH19SameDaySubmissionSupportEmailConfigTest {
+    private DelayedSH19SameDaySubmissionSupportEmailConfig testConfig;
+
+    @BeforeEach
+    void setUp() {
+        testConfig = new DelayedSH19SameDaySubmissionSupportEmailConfig();
+    }
+
+    @Test
+    void setGetSupportEmailAddress() {
+        testConfig.setSupportEmailAddress("email");
+        assertThat(testConfig.getSupportEmailAddress(), is("email"));
+    }
+
+    @Test
+    void testEqualsAndHashcode() {
+        EqualsVerifier.forClass(DelayedSH19SameDaySubmissionSupportEmailConfig.class)
+            .usingGetClass()
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/config/DelayedSubmissionSupportEmailConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/config/DelayedSubmissionSupportEmailConfigTest.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.efs.api.email.config;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSubmissionSupportEmailConfigTest {
+    private DelayedSubmissionSupportEmailConfig testConfig;
+
+    @BeforeEach
+    void setUp() {
+        testConfig = new DelayedSubmissionSupportEmailConfig();
+    }
+
+    @Test
+    void getSupportEmailAddress() {
+        assertThat(testConfig.getSupportEmailAddress(), is(nullValue()));
+    }
+
+    @Test
+    void setSupportEmailAddress() {
+        testConfig.setSupportEmailAddress("expected");
+        assertThat(testConfig.getSupportEmailAddress(), is("expected"));
+    }
+
+    @Test
+    void testEqualsAndHashcode() {
+        EqualsVerifier.forClass(DelayedSubmissionSupportEmailConfig.class).usingGetClass().suppress(
+            Warning.NONFINAL_FIELDS).verify();
+    }
+    
+    
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSH19SameDaySubmissionSupportEmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSH19SameDaySubmissionSupportEmailMapperTest.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.efs.api.email.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.efs.api.email.config.DelayedSH19SameDaySubmissionSupportEmailConfig;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailData;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportModel;
+import uk.gov.companieshouse.efs.api.email.model.EmailDocument;
+import uk.gov.companieshouse.efs.api.util.IdentifierGeneratable;
+import uk.gov.companieshouse.efs.api.util.TimestampGenerator;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSH19SameDaySubmissionSupportEmailMapperTest {
+    private DelayedSH19SameDaySubmissionSupportEmailMapper testMapper;
+
+    @Mock
+    private DelayedSH19SameDaySubmissionSupportEmailConfig config;
+    @Mock
+    private IdentifierGeneratable idGenerator;
+    @Mock
+    private TimestampGenerator<LocalDateTime> timestampGenerator;
+    @Mock
+    private DelayedSubmissionSupportEmailModel model;
+    @Mock
+    private DelayedSubmissionSupportModel delayedSubmissionSupportModel;
+
+    @BeforeEach
+    void setUp() {
+        testMapper = new DelayedSH19SameDaySubmissionSupportEmailMapper(config, idGenerator,
+            timestampGenerator);
+    }
+
+    @Test
+    void mapSupportModelToEmailDocument() {
+        LocalDateTime createAtLocalDateTime = LocalDateTime.of(2020, Month.JUNE, 2, 0, 0);
+
+        when(config.getSubject()).thenReturn("EFS submission delay alert: Same day SH19");
+        when(config.getAppId()).thenReturn(
+            "efs-submission-api.efs_submission_delayed_sh19_sameday");
+        when(config.getMessageType()).thenReturn("efs_submission_delayed_sh19_sameday");
+        when(config.getTopic()).thenReturn("email-send");
+        when(config.getSupportEmailAddress()).thenReturn("test_support@ch.gov.uk");
+        when(idGenerator.generateId()).thenReturn("123");
+        when(timestampGenerator.generateTimestamp()).thenReturn(createAtLocalDateTime);
+        when(config.getDateFormat()).thenReturn("dd MMMM yyyy");
+        when(model.getDelayedSubmissions()).thenReturn(
+            Collections.singletonList(delayedSubmissionSupportModel));
+        when(model.getThresholdInMinutes()).thenReturn(60);
+
+        //when
+        EmailDocument<DelayedSubmissionSupportEmailData> actual = testMapper.map(model);
+
+        //then
+        assertEquals(expectedDocument(), actual);
+        verify(idGenerator).generateId();
+        verify(timestampGenerator).generateTimestamp();
+    }
+
+    private EmailDocument<DelayedSubmissionSupportEmailData> expectedDocument() {
+        return EmailDocument.<DelayedSubmissionSupportEmailData>builder()
+            .withEmailTemplateAppId("efs-submission-api.efs_submission_delayed_sh19_sameday")
+            .withMessageId("123")
+            .withEmailTemplateMessageType("efs_submission_delayed_sh19_sameday")
+            .withRecipientEmailAddress("test_support@ch.gov.uk")
+            .withCreatedAt("02 June 2020")
+            .withTopic("email-send")
+            .withData(DelayedSubmissionSupportEmailData.builder()
+                .withTo("test_support@ch.gov.uk")
+                .withSubject("EFS submission delay alert: Same day SH19")
+                .withDelayedSubmissions(Collections.singletonList(delayedSubmissionSupportModel))
+                .withThresholdInMinutes(60)
+                .build())
+            .build();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSubmissionSupportEmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/DelayedSubmissionSupportEmailMapperTest.java
@@ -67,6 +67,7 @@ class DelayedSubmissionSupportEmailMapperTest {
         when(config.getDateFormat()).thenReturn("dd MMMM yyyy");
 
         when(delayedSubmissionSupportEmailModel.getDelayedSubmissions()).thenReturn(Collections.singletonList(delayedSubmissionSupportModel));
+        when(delayedSubmissionSupportEmailModel.getThresholdInMinutes()).thenReturn(99);
 
         //when
         EmailDocument<DelayedSubmissionSupportEmailData> actual = delayedSubmissionSupportEmailMapper.map(delayedSubmissionSupportEmailModel);
@@ -90,6 +91,7 @@ class DelayedSubmissionSupportEmailMapperTest {
                                 .withTo("internal_RP_demo@ch.gov.uk")
                                 .withSubject("EFS Submission delayed submission")
                                 .withDelayedSubmissions(Collections.singletonList(delayedSubmissionSupportModel))
+                                .withThresholdInMinutes(99)
                                 .build())
                 .build();
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/EmailMapperFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/EmailMapperFactoryTest.java
@@ -35,6 +35,8 @@ class EmailMapperFactoryTest {
     @Mock
     private DelayedSubmissionSupportEmailMapper delayedSubmissionSupportEmailMapper;
     @Mock
+    private DelayedSH19SameDaySubmissionSupportEmailMapper delayedSH19SameDaySubmissionSupportEmailMapper;
+    @Mock
     private DelayedSubmissionBusinessEmailMapper delayedSubmissionBusinessEmailMapper;
     @Mock
     private PaymentReportEmailMapper paymentReportEmailMapper;
@@ -49,6 +51,8 @@ class EmailMapperFactoryTest {
             .withInternalFailedConversionEmailMapper(internalFailedConversionEmailMapper)
             .withInternalSubmissionEmailMapper(internalSubmissionEmailMapper)
             .withDelayedSubmissionSupportEmailMapper(delayedSubmissionSupportEmailMapper)
+            .withDelayedSH19SameDaySubmissionSupportEmailMapper(
+                delayedSH19SameDaySubmissionSupportEmailMapper)
             .withDelayedSubmissionBusinessEmailMapper(delayedSubmissionBusinessEmailMapper)
             .withPaymentReportEmailMapper(paymentReportEmailMapper).build();
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/InternalEmailMapperFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/InternalEmailMapperFactoryTest.java
@@ -19,6 +19,9 @@ class InternalEmailMapperFactoryTest {
     @Mock
     private DelayedSubmissionSupportEmailMapper delayedSupportMapper;
     @Mock
+    private DelayedSH19SameDaySubmissionSupportEmailMapper
+        delayedSH19SameDaySubmissionSupportEmailMapper;
+    @Mock
     private InternalAvFailedEmailMapper avFailedMapper;
     @Mock
     private InternalFailedConversionEmailMapper failedConversionMapper;
@@ -30,7 +33,8 @@ class InternalEmailMapperFactoryTest {
 
     @BeforeEach
     void setUp() {
-        testFactory = new InternalEmailMapperFactory(delayedBusinessMapper, delayedSupportMapper, avFailedMapper,
+        testFactory = new InternalEmailMapperFactory(delayedBusinessMapper, delayedSupportMapper,
+            delayedSH19SameDaySubmissionSupportEmailMapper, avFailedMapper,
             failedConversionMapper, submissionMapper, paymentReportMapper);
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessEmailModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessEmailModelTest.java
@@ -1,0 +1,102 @@
+package uk.gov.companieshouse.efs.api.email.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Collections;
+import java.util.List;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSubmissionBusinessEmailModelTest {
+    private static final int DELAY_IN_MINUTES = 60;
+    private DelayedSubmissionBusinessEmailModel testModel;
+
+    @BeforeEach
+    void setUp() {
+        testModel = new DelayedSubmissionBusinessEmailModel(null, null, DELAY_IN_MINUTES);
+    }
+
+    @Test
+    void getDelayedSubmissions() {
+        assertThat(testModel.getDelayedSubmissions(), is(nullValue()));
+    }
+
+    @Test
+    void setDelayedSubmissions() {
+        final DelayedSubmissionBusinessModel businessModel =
+            new DelayedSubmissionBusinessModel(null, null, null, null, null);
+        final List<DelayedSubmissionBusinessModel> expected = Collections.singletonList(businessModel);
+
+        testModel.setDelayedSubmissions(expected);
+
+        assertThat(testModel.getDelayedSubmissions(), contains(businessModel));
+    }
+
+    @Test
+    void getEmailAddress() {
+        assertThat(testModel.getEmailAddress(), is(nullValue()));
+    }
+
+    @Test
+    void setEmailAddress() {
+        testModel.setEmailAddress("expected");
+        assertThat(testModel.getEmailAddress(), is("expected"));
+    }
+
+    @Test
+    void getNumberOfDelayedSubmissions() {
+        assertThat(testModel.getNumberOfDelayedSubmissions(), is(0));
+
+        final List<DelayedSubmissionBusinessModel> expected = Collections.singletonList(
+            new DelayedSubmissionBusinessModel(null, null, null, null, null));
+
+        testModel.setDelayedSubmissions(expected);
+
+        assertThat(testModel.getNumberOfDelayedSubmissions(), is(1));
+    }
+
+    @Test
+    void getDelayInMinutes() {
+        assertThat(testModel.getDelayInMinutes(), is(DELAY_IN_MINUTES));
+    }
+
+    @Test
+    void setDelayInMinutes() {
+        testModel.setDelayInMinutes(DELAY_IN_MINUTES + 5);
+        assertThat(testModel.getDelayInMinutes(), is(DELAY_IN_MINUTES + 5));
+    }
+
+    @Test
+    void getDelayInHours() {
+        assertThat(testModel.getDelayInHours(), is(DELAY_IN_MINUTES / 60));
+    }
+
+    @Test
+    void setDelayInHours() {
+        testModel.setDelayInHours(3);
+        assertThat(testModel.getDelayInHours(), is(3));
+    }
+
+    @Test
+    void testEquals() {
+        EqualsVerifier.forClass(DelayedSubmissionBusinessEmailModel.class)
+            .usingGetClass()
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+
+    @Test
+    void testToString() {
+        assertThat(testModel.toString(),
+            is("DelayedSubmissionBusinessEmailModel[delayInMinutes=60,delayedSubmissions=<null>,emailAddress=<null>]"));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionBusinessModelTest.java
@@ -1,0 +1,67 @@
+package uk.gov.companieshouse.efs.api.email.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSubmissionBusinessModelTest {
+    private DelayedSubmissionBusinessModel testModel;
+
+    @BeforeEach
+    void setUp() {
+        testModel = new DelayedSubmissionBusinessModel(null, null, null, null, null);
+    }
+
+    @Test
+    void setGetConfirmationReference() {
+        testModel.setConfirmationReference("expected");
+        assertThat(testModel.getConfirmationReference(), is("expected"));
+    }
+
+    @Test
+    void setGetCompanyNumber() {
+        testModel.setCompanyNumber("expected");
+        assertThat(testModel.getCompanyNumber(), is("expected"));
+    }
+
+    @Test
+    void setGetFormType() {
+        testModel.setFormType("expected");
+        assertThat(testModel.getFormType(), is("expected"));
+    }
+
+    @Test
+    void setGetEmail() {
+        testModel.setEmail("expected");
+        assertThat(testModel.getEmail(), is("expected"));
+    }
+
+    @Test
+    void setGetSubmissionDate() {
+        testModel.setSubmissionDate("expected");
+        assertThat(testModel.getSubmissionDate(), is("expected"));
+    }
+
+    @Test
+    void testEquals() {
+        EqualsVerifier.forClass(DelayedSubmissionBusinessModel.class)
+            .usingGetClass()
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+
+    @Test
+    void testToString() {
+        assertThat(testModel.toString(),
+            is("DelayedSubmissionBusinessModel[companyNumber=<null>," 
+                + "confirmationReference=<null>,email=<null>,formType=<null>," 
+                + "submissionDate=<null>]"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailDataTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailDataTest.java
@@ -1,0 +1,65 @@
+package uk.gov.companieshouse.efs.api.email.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+import java.util.Collections;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSubmissionSupportEmailDataTest {
+    private DelayedSubmissionSupportEmailData testData;
+
+    @BeforeEach
+    void setUp() {
+        testData = new DelayedSubmissionSupportEmailData(null, null, null, 0);
+    }
+
+    @Test
+    void setGetTo() {
+        testData.setTo("expected");
+        assertThat(testData.getTo(), is("expected"));
+    }
+
+    @Test
+    void setGetSubject() {
+        testData.setSubject("expected");
+        assertThat(testData.getSubject(), is("expected"));
+    }
+
+    @Test
+    void setGetDelayedSubmissions() {
+        final DelayedSubmissionSupportModel model =
+            new DelayedSubmissionSupportModel(null, null, null, null, null);
+
+        testData.setDelayedSubmissions(Collections.singletonList(model));
+        assertThat(testData.getDelayedSubmissions(), contains(model));
+    }
+
+    @Test
+    void setGetThresholdInMinutes() {
+        testData.setThresholdInMinutes(3000);
+        assertThat(testData.getThresholdInMinutes(), is(3000));
+    }
+
+    @Test
+    void testEquals() {
+        EqualsVerifier.forClass(DelayedSubmissionSupportEmailData.class)
+            .usingGetClass()
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+
+    @Test
+    void testToString() {
+        assertThat(testData.toString(),
+            is("DelayedSubmissionSupportEmailData[delayedSubmissions=<null>,subject=<null>," 
+                + "thresholdInMinutes=0,to=<null>]"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModelTest.java
@@ -18,7 +18,7 @@ class DelayedSubmissionSupportEmailModelTest {
 
     @BeforeEach
     void setUp() {
-        testModel = new DelayedSubmissionSupportEmailModel(null);
+        testModel = new DelayedSubmissionSupportEmailModel(null, 0);
     }
 
     @Test
@@ -30,8 +30,15 @@ class DelayedSubmissionSupportEmailModelTest {
     @Test
     void getNumberOfDelayedSubmissions() {
         testModel.setDelayedSubmissions(
-            Collections.singletonList(new DelayedSubmissionSupportModel(null, null, null)));
+            Collections.singletonList(new DelayedSubmissionSupportModel(null, null, null,
+                null, null)));
         assertThat(testModel.getNumberOfDelayedSubmissions(), is(1));
+    }
+
+    @Test
+    void setGetThresholdInMinutes() {
+        testModel.setThresholdInMinutes(3000);
+        assertThat(testModel.getThresholdInMinutes(), is(3000));
     }
 
     @Test
@@ -43,6 +50,6 @@ class DelayedSubmissionSupportEmailModelTest {
     @Test
     void testToString() {
         assertThat(testModel.toString(),
-            is("DelayedSubmissionSupportEmailModel[delayedSubmissions=<null>]"));
+            is("DelayedSubmissionSupportEmailModel[delayedSubmissions=<null>,thresholdInMinutes=0]"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportEmailModelTest.java
@@ -1,0 +1,48 @@
+package uk.gov.companieshouse.efs.api.email.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.util.Collections;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSubmissionSupportEmailModelTest {
+    private DelayedSubmissionSupportEmailModel testModel;
+
+    @BeforeEach
+    void setUp() {
+        testModel = new DelayedSubmissionSupportEmailModel(null);
+    }
+
+    @Test
+    void setGetDelayedSubmissions() {
+        testModel.setDelayedSubmissions(Collections.emptyList());
+        assertThat(testModel.getDelayedSubmissions(), is(empty()));
+    }
+
+    @Test
+    void getNumberOfDelayedSubmissions() {
+        testModel.setDelayedSubmissions(
+            Collections.singletonList(new DelayedSubmissionSupportModel(null, null, null)));
+        assertThat(testModel.getNumberOfDelayedSubmissions(), is(1));
+    }
+
+    @Test
+    void testEquals() {
+        EqualsVerifier.forClass(DelayedSubmissionSupportEmailModel.class).usingGetClass().suppress(
+            Warning.NONFINAL_FIELDS).verify();
+    }
+
+    @Test
+    void testToString() {
+        assertThat(testModel.toString(),
+            is("DelayedSubmissionSupportEmailModel[delayedSubmissions=<null>]"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModelTest.java
@@ -21,7 +21,7 @@ class DelayedSubmissionSupportModelTest {
     @BeforeEach
     void setUp() {
         testModel = new DelayedSubmissionSupportModel("submissionId", "confirmationReference",
-            NOW.toString());
+            NOW.toString(), "customerEmail", "companyNumber");
     }
 
     @Test
@@ -36,14 +36,21 @@ class DelayedSubmissionSupportModelTest {
     }
 
     @Test
-    void getConfirmationReference() {
-        assertThat(testModel.getConfirmationReference(), is("confirmationReference"));
+    void setGetConfirmationReference() {
+        testModel.setConfirmationReference("expected");
+        assertThat(testModel.getConfirmationReference(), is("expected"));
     }
 
     @Test
-    void setConfirmationReference() {
-        testModel.setConfirmationReference("expected");
-        assertThat(testModel.getConfirmationReference(), is("expected"));
+    void setGetCompanyNumber() {
+        testModel.setCompanyNumber("expected");
+        assertThat(testModel.getCompanyNumber(), is("expected"));
+    }
+
+    @Test
+    void setGetCustomerEmail() {
+        testModel.setCustomerEmail("expected");
+        assertThat(testModel.getCustomerEmail(), is("expected"));
     }
 
     @Test
@@ -68,7 +75,8 @@ class DelayedSubmissionSupportModelTest {
     @Test
     void testToString() {
         assertThat(testModel.toString(),
-            is("DelayedSubmissionSupportModel[confirmationReference=confirmationReference,submissionId=submissionId,submittedAt="
-                + NOW.toString() + "]"));
+            is("DelayedSubmissionSupportModel[companyNumber=companyNumber,"
+                + "confirmationReference=confirmationReference,customerEmail=customerEmail,"
+                + "submissionId=submissionId,submittedAt=" + NOW + "]"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/model/DelayedSubmissionSupportModelTest.java
@@ -1,0 +1,74 @@
+package uk.gov.companieshouse.efs.api.email.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.LocalDateTime;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSubmissionSupportModelTest {
+    private static final LocalDateTime NOW = LocalDateTime.now();
+    private static final LocalDateTime INSTANT = NOW.plusMinutes(2);
+
+    private DelayedSubmissionSupportModel testModel;
+
+    @BeforeEach
+    void setUp() {
+        testModel = new DelayedSubmissionSupportModel("submissionId", "confirmationReference",
+            NOW.toString());
+    }
+
+    @Test
+    void getSubmissionId() {
+        assertThat(testModel.getSubmissionId(), is("submissionId"));
+    }
+
+    @Test
+    void setGetSubmissionId() {
+        testModel.setSubmissionId("expected");
+        assertThat(testModel.getSubmissionId(), is("expected"));
+    }
+
+    @Test
+    void getConfirmationReference() {
+        assertThat(testModel.getConfirmationReference(), is("confirmationReference"));
+    }
+
+    @Test
+    void setConfirmationReference() {
+        testModel.setConfirmationReference("expected");
+        assertThat(testModel.getConfirmationReference(), is("expected"));
+    }
+
+    @Test
+    void getSubmittedAt() {
+        assertThat(testModel.getSubmittedAt(), is(NOW.toString()));
+    }
+
+    @Test
+    void setSubmittedAt() {
+        testModel.setSubmittedAt(INSTANT.toString());
+        assertThat(testModel.getSubmittedAt(), is(INSTANT.toString()));
+    }
+
+    @Test
+    void testEqualsAndHashcode() {
+        EqualsVerifier.forClass(DelayedSubmissionSupportModel.class)
+            .usingGetClass()
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+
+    @Test
+    void testToString() {
+        assertThat(testModel.toString(),
+            is("DelayedSubmissionSupportModel[confirmationReference=confirmationReference,submissionId=submissionId,submittedAt="
+                + NOW.toString() + "]"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/controller/HandleDelayedSubmissionsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/controller/HandleDelayedSubmissionsControllerTest.java
@@ -3,13 +3,17 @@ package uk.gov.companieshouse.efs.api.events.controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.efs.api.events.service.DelayedSubmissionHandlerContext;
 import uk.gov.companieshouse.efs.api.events.service.EventService;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class HandleDelayedSubmissionsControllerTest {
@@ -27,9 +31,21 @@ class HandleDelayedSubmissionsControllerTest {
     @Test
     void testControllerReturns200OKIfNoExceptionThrownByEventService() {
         //when
-        ResponseEntity<Void> actual = controller.handleDelayedSubmissions();
+        ResponseEntity<Void> actual = controller.handleDelayedSubmissions(null);
 
         //then
+        verify(eventService).handleDelayedSubmissions(DelayedSubmissionHandlerContext.ServiceLevel.STANDARD);
+        assertEquals(HttpStatus.OK, actual.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @EnumSource(DelayedSubmissionHandlerContext.ServiceLevel.class)
+    void handleDelayedSubmissions(DelayedSubmissionHandlerContext.ServiceLevel serviceLevel) {
+        // when
+        ResponseEntity<Void> actual = controller.handleDelayedSubmissions(
+            serviceLevel);
+
+        verify(eventService).handleDelayedSubmissions(serviceLevel);
         assertEquals(HttpStatus.OK, actual.getStatusCode());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerContextTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerContextTest.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedSubmissionHandlerContextTest {
+    private DelayedSubmissionHandlerContext testContext;
+
+    @Mock
+    private StandardServiceDelayedHandler standard;
+    @Mock
+    private SameDayServiceDelayedHandler sameday;
+
+    private Set<DelayedSubmissionHandlerStrategy> implementations;
+
+    @BeforeEach
+    void setUp() {
+        when(standard.getServiceLevel()).thenReturn(
+            DelayedSubmissionHandlerContext.ServiceLevel.STANDARD);
+        when(sameday.getServiceLevel()).thenReturn(
+            DelayedSubmissionHandlerContext.ServiceLevel.SAMEDAY);
+        implementations = new HashSet<>(Arrays.asList(standard, sameday));
+        testContext = new DelayedSubmissionHandlerContext(implementations);
+    }
+
+    @Test
+    void getStandardStrategy() {
+        assertThat(testContext.getStrategy(DelayedSubmissionHandlerContext.ServiceLevel.STANDARD),
+            is(sameInstance(standard)));
+    }
+
+    @Test
+    void getSameDayStrategy() {
+        assertThat(testContext.getStrategy(DelayedSubmissionHandlerContext.ServiceLevel.SAMEDAY),
+            is(sameInstance(sameday)));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandlerTest.java
@@ -10,6 +10,7 @@ import static uk.gov.companieshouse.efs.api.events.service.SameDayServiceDelayed
 import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +31,9 @@ import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository
 class SameDayServiceDelayedHandlerTest {
     private static final int SUPPORT_DELAY = 60;
     private static final LocalDateTime NOW = LocalDateTime.now();
+    static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+    private static final DateTimeFormatter FORMATTER =
+        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT).withZone(UTC_ZONE);
 
     private SameDayServiceDelayedHandler testHandler;
 
@@ -90,7 +94,7 @@ class SameDayServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSH19SubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    .format(FORMATTER),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY));
         verifyNoMoreInteractions(emailService);
@@ -115,7 +119,7 @@ class SameDayServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSH19SubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    .format(FORMATTER),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY));
         verifyNoMoreInteractions(emailService);

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandlerTest.java
@@ -1,0 +1,116 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.efs.api.events.service.SameDayServiceDelayedHandler.DELAYED_STATUSES;
+import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.efs.api.email.EmailService;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportModel;
+import uk.gov.companieshouse.efs.api.submissions.model.Submission;
+import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SameDayServiceDelayedHandlerTest {
+    private static final int SUPPORT_DELAY = 60;
+    private static final LocalDateTime NOW = LocalDateTime.now();
+
+    private SameDayServiceDelayedHandler testHandler;
+
+    @Mock
+    private SubmissionRepository repository;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private Submission submission;
+
+
+    @BeforeEach
+    void setUp() {
+        testHandler = new SameDayServiceDelayedHandler(repository, emailService, SUPPORT_DELAY);
+    }
+
+    @Test
+    void getServiceLevel() {
+        assertThat(testHandler.getServiceLevel(),
+            is(DelayedSubmissionHandlerContext.ServiceLevel.SAMEDAY));
+    }
+
+    @Test
+    void findDelayedSubmissions() {
+        // when
+        testHandler.findDelayedSubmissions(NOW);
+
+        // then
+        verify(repository).findDelayedSameDaySubmissions(DELAYED_STATUSES,
+            NOW.minusMinutes(SUPPORT_DELAY));
+    }
+
+    @Test
+    void buildAndSendEmailsWhenNoneDelayed() {
+        // when
+        testHandler.buildAndSendEmails(Collections.emptyList(), NOW);
+
+        // then
+        verifyNoInteractions(emailService);
+    }
+
+    @Test
+    void buildAndSendEmailsWhenSomeDelayedForSupport() {
+        // given
+        final LocalDateTime delayedFrom = NOW.minusMinutes(SUPPORT_DELAY);
+        final List<Submission> submissions = Collections.singletonList(submission);
+
+        when(submission.getId()).thenReturn("123abd");
+        when(submission.getConfirmationReference()).thenReturn("345efg");
+        when(submission.getSubmittedAt()).thenReturn(delayedFrom.minusSeconds(5));
+
+        // when
+        testHandler.buildAndSendEmails(submissions, NOW);
+
+        // then
+        verify(emailService).sendDelayedSubmissionSupportEmail(
+            new DelayedSubmissionSupportEmailModel(Collections.singletonList(
+                new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
+                    .format(
+                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+        verifyNoMoreInteractions(emailService);
+    }
+
+    @Test
+    void buildAndSendEmailsWhenSomeDelayedForSupportAndSubmittedAtMissing() {
+        // given
+        final LocalDateTime delayedFrom = NOW.minusHours(SUPPORT_DELAY);
+        final List<Submission> submissions = Collections.singletonList(submission);
+
+        when(submission.getId()).thenReturn("123abd");
+        when(submission.getConfirmationReference()).thenReturn("345efg");
+        when(submission.getCreatedAt()).thenReturn(delayedFrom.minusSeconds(5));
+
+        // when
+        testHandler.buildAndSendEmails(submissions, NOW);
+
+        // then
+        verify(emailService).sendDelayedSubmissionSupportEmail(
+            new DelayedSubmissionSupportEmailModel(Collections.singletonList(
+                new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
+                    .format(
+                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+        verifyNoMoreInteractions(emailService);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/SameDayServiceDelayedHandlerTest.java
@@ -10,7 +10,6 @@ import static uk.gov.companieshouse.efs.api.events.service.SameDayServiceDelayed
 import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
@@ -91,7 +90,6 @@ class SameDayServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSH19SubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .atZone(ZoneId.of("Europe/London"))
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY));
@@ -117,7 +115,6 @@ class SameDayServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSH19SubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .atZone(ZoneId.of("Europe/London"))
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY));

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
@@ -10,6 +10,7 @@ import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelaye
 import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,6 +38,9 @@ class StandardServiceDelayedHandlerTest {
     private static final int SUPPORT_DELAY = 6;
     private static final int BUSINESS_DELAY = 72;
     private static final LocalDateTime NOW = LocalDateTime.now();
+    static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+    private static final DateTimeFormatter FORMATTER =
+        DateTimeFormatter.ofPattern(SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT).withZone(UTC_ZONE);
 
     private StandardServiceDelayedHandler testHandler;
 
@@ -102,7 +106,7 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    .format(FORMATTER),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
         verifyNoMoreInteractions(emailService);
@@ -129,7 +133,7 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    .format(FORMATTER),
                     "email", "number")), SUPPORT_DELAY * 60));
         verifyNoMoreInteractions(emailService);
         verifyNoInteractions(formCategoryToEmailAddressService);
@@ -159,7 +163,7 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    .format(FORMATTER),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
         verify(emailService).sendDelayedSubmissionBusinessEmail(
@@ -194,7 +198,7 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    .format(FORMATTER),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
         verify(emailService).sendDelayedSubmissionBusinessEmail(
@@ -234,7 +238,7 @@ class StandardServiceDelayedHandlerTest {
         // then
         final DelayedSubmissionSupportModel supportModel =
             new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                .format(FORMATTER),
                 submission.getPresenter().getEmail(), submission.getCompany().getCompanyNumber());
 
         verify(emailService).sendDelayedSubmissionSupportEmail(

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
@@ -1,0 +1,254 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT;
+import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionStatus;
+import uk.gov.companieshouse.efs.api.email.EmailService;
+import uk.gov.companieshouse.efs.api.email.FormCategoryToEmailAddressService;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionBusinessEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionBusinessModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportEmailModel;
+import uk.gov.companieshouse.efs.api.email.model.DelayedSubmissionSupportModel;
+import uk.gov.companieshouse.efs.api.submissions.model.Company;
+import uk.gov.companieshouse.efs.api.submissions.model.FormDetails;
+import uk.gov.companieshouse.efs.api.submissions.model.Presenter;
+import uk.gov.companieshouse.efs.api.submissions.model.Submission;
+import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StandardServiceDelayedHandlerTest {
+    private static final int SUPPORT_DELAY = 6;
+    private static final int BUSINESS_DELAY = 72;
+    private static final LocalDateTime NOW = LocalDateTime.now();
+
+    private StandardServiceDelayedHandler testHandler;
+
+    @Mock
+    private SubmissionRepository repository;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private FormCategoryToEmailAddressService formCategoryToEmailAddressService;
+    @Mock
+    private Submission submission;
+
+
+    @BeforeEach
+    void setUp() {
+        testHandler = new StandardServiceDelayedHandler(repository, emailService,
+            formCategoryToEmailAddressService, SUPPORT_DELAY, BUSINESS_DELAY);
+    }
+
+    @Test
+    void getServiceLevel() {
+        assertThat(testHandler.getServiceLevel(),
+            is(DelayedSubmissionHandlerContext.ServiceLevel.STANDARD));
+    }
+
+    @Test
+    void findDelayedSubmissions() {
+        // when
+        testHandler.findDelayedSubmissions(NOW);
+
+        // then
+        verify(repository).findDelayedSubmissions(SubmissionStatus.PROCESSING,
+            NOW.minusHours(SUPPORT_DELAY));
+    }
+
+    @Test
+    void buildAndSendEmailsWhenNoneDelayed() {
+        // when
+        testHandler.buildAndSendEmails(Collections.emptyList(), NOW);
+
+        // then
+        verifyNoInteractions(emailService, formCategoryToEmailAddressService);
+    }
+
+
+    @Test
+    void buildAndSendEmailsWhenSomeDelayedForSupport() {
+        // given
+        final LocalDateTime delayedFrom = NOW.minusHours(SUPPORT_DELAY);
+        final List<Submission> submissions = Collections.singletonList(submission);
+
+        when(submission.getId()).thenReturn("123abd");
+        when(submission.getConfirmationReference()).thenReturn("345efg");
+        when(submission.getLastModifiedAt()).thenReturn(delayedFrom);
+        when(submission.getSubmittedAt()).thenReturn(delayedFrom.minusSeconds(5));
+
+        // when
+        testHandler.buildAndSendEmails(submissions, NOW);
+
+        // then
+        verify(emailService).sendDelayedSubmissionSupportEmail(
+            new DelayedSubmissionSupportEmailModel(Collections.singletonList(
+                new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
+                    .format(
+                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+        verifyNoMoreInteractions(emailService);
+        verifyNoInteractions(formCategoryToEmailAddressService);
+    }
+
+    @Test
+    void buildAndSendEmailsWhenSomeDelayedForSupportAndSubmittedAtMissing() {
+        // given
+        final LocalDateTime delayedFrom = NOW.minusHours(SUPPORT_DELAY);
+        final List<Submission> submissions = Collections.singletonList(submission);
+
+        when(submission.getId()).thenReturn("123abd");
+        when(submission.getConfirmationReference()).thenReturn("345efg");
+        when(submission.getLastModifiedAt()).thenReturn(delayedFrom);
+        when(submission.getCreatedAt()).thenReturn(delayedFrom.minusSeconds(5));
+
+        // when
+        testHandler.buildAndSendEmails(submissions, NOW);
+
+        // then
+        verify(emailService).sendDelayedSubmissionSupportEmail(
+            new DelayedSubmissionSupportEmailModel(Collections.singletonList(
+                new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
+                    .format(
+                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+        verifyNoMoreInteractions(emailService);
+        verifyNoInteractions(formCategoryToEmailAddressService);
+    }
+
+    @Test
+    void buildAndSendEmailsWhenSomeDelayedForSupportAndBusiness() {
+        // given
+        final LocalDateTime delayedFrom = NOW.minusHours(BUSINESS_DELAY);
+        final List<Submission> submissions = Collections.singletonList(submission);
+
+        when(submission.getId()).thenReturn("123abd");
+        when(submission.getConfirmationReference()).thenReturn("345efg");
+        when(submission.getCompany()).thenReturn(new Company("00000007", "RITCHIE GROUP"));
+        when(submission.getFormDetails()).thenReturn(
+            FormDetails.builder().withFormType("CC01").build());
+        when(submission.getPresenter()).thenReturn(new Presenter("demo@ch.gov.uk"));
+        when(submission.getLastModifiedAt()).thenReturn(delayedFrom.minusSeconds(1));
+        when(submission.getSubmittedAt()).thenReturn(delayedFrom.minusSeconds(5));
+        when(formCategoryToEmailAddressService.getEmailAddressForFormCategory("CC01")).thenReturn(
+            "cc@ch.gov.uk");
+
+        // when
+        testHandler.buildAndSendEmails(submissions, NOW);
+
+        // then
+        verify(emailService).sendDelayedSubmissionSupportEmail(
+            new DelayedSubmissionSupportEmailModel(Collections.singletonList(
+                new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
+                    .format(
+                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+        verify(emailService).sendDelayedSubmissionBusinessEmail(
+            new DelayedSubmissionBusinessEmailModel(
+                Collections.singletonList(createBusinessModel(delayedFrom, "CC01")), "cc@ch.gov.uk",
+                BUSINESS_DELAY));
+        verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("CC01");
+        verifyNoMoreInteractions(emailService, formCategoryToEmailAddressService);
+    }
+
+    @Test
+    void buildAndSendEmailsWhenSomeDelayedForSupportAndBusinessAndSubmittedAtMissing() {
+        //given
+        final LocalDateTime delayedFrom = NOW.minusHours(BUSINESS_DELAY);
+        final List<Submission> submissions = Collections.singletonList(submission);
+
+        when(submission.getId()).thenReturn("123abd");
+        when(submission.getConfirmationReference()).thenReturn("345efg");
+        when(submission.getCompany()).thenReturn(new Company("00000007", "RITCHIE GROUP"));
+        when(submission.getFormDetails()).thenReturn(
+            FormDetails.builder().withFormType("CC01").build());
+        when(submission.getPresenter()).thenReturn(new Presenter("demo@ch.gov.uk"));
+        when(submission.getLastModifiedAt()).thenReturn(delayedFrom.minusSeconds(1));
+        when(submission.getSubmittedAt()).thenReturn(delayedFrom.minusSeconds(5));
+        when(formCategoryToEmailAddressService.getEmailAddressForFormCategory("CC01")).thenReturn(
+            "cc@ch.gov.uk");
+
+        // when
+        testHandler.buildAndSendEmails(submissions, NOW);
+
+        // then
+        verify(emailService).sendDelayedSubmissionSupportEmail(
+            new DelayedSubmissionSupportEmailModel(Collections.singletonList(
+                new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
+                    .format(
+                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+        verify(emailService).sendDelayedSubmissionBusinessEmail(
+            new DelayedSubmissionBusinessEmailModel(
+                Collections.singletonList(createBusinessModel(delayedFrom, "CC01")), "cc@ch.gov.uk",
+                BUSINESS_DELAY));
+        verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("CC01");
+        verifyNoMoreInteractions(emailService, formCategoryToEmailAddressService);
+    }
+
+    @Test
+    void buildAndSendEmailsWhenSomeDelayedForSupportAndBusinessToMultipleUnitsIfDifferentSubmissionCategories() {
+        //given
+        final LocalDateTime delayedFrom = NOW.minusHours(BUSINESS_DELAY);
+        final List<Submission> submissions = Arrays.asList(submission, submission, submission);
+
+        when(submission.getId()).thenReturn("123abd");
+        when(submission.getConfirmationReference()).thenReturn("345efg");
+        when(submission.getCompany()).thenReturn(new Company("00000007", "RITCHIE GROUP"));
+        when(submission.getFormDetails()).thenReturn(
+            FormDetails.builder().withFormType("CC01").build())
+            .thenReturn(FormDetails.builder().withFormType("RP03").build())
+            .thenReturn(FormDetails.builder().withFormType("CC03").build());
+        when(submission.getPresenter()).thenReturn(new Presenter("demo@ch.gov.uk"));
+        when(submission.getLastModifiedAt()).thenReturn(delayedFrom.minusSeconds(1));
+        when(submission.getSubmittedAt()).thenReturn(delayedFrom.minusSeconds(5));
+        when(formCategoryToEmailAddressService.getEmailAddressForFormCategory("CC01")).thenReturn(
+            "cc@ch.gov.uk");
+        when(formCategoryToEmailAddressService.getEmailAddressForFormCategory("CC03")).thenReturn(
+            "cc@ch.gov.uk");
+        when(formCategoryToEmailAddressService.getEmailAddressForFormCategory("RP03")).thenReturn(
+            "rp@ch.gov.uk");
+
+        // when
+        testHandler.buildAndSendEmails(submissions, NOW);
+
+        // then
+        final DelayedSubmissionSupportModel supportModel =
+            new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
+                .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)));
+
+        verify(emailService).sendDelayedSubmissionSupportEmail(
+            new DelayedSubmissionSupportEmailModel(
+                Arrays.asList(supportModel, supportModel, supportModel)));
+        verify(emailService).sendDelayedSubmissionBusinessEmail(
+            new DelayedSubmissionBusinessEmailModel(
+                Arrays.asList(createBusinessModel(delayedFrom, "CC01"),
+                    createBusinessModel(delayedFrom, "CC03")), "cc@ch.gov.uk", BUSINESS_DELAY));
+        verify(emailService).sendDelayedSubmissionBusinessEmail(
+            new DelayedSubmissionBusinessEmailModel(
+                Collections.singletonList(createBusinessModel(delayedFrom, "RP03")), "rp@ch.gov.uk",
+                BUSINESS_DELAY));
+        verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("CC01");
+        verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("RP03");
+        verifyNoMoreInteractions(emailService, formCategoryToEmailAddressService);
+    }
+
+    private DelayedSubmissionBusinessModel createBusinessModel(final LocalDateTime delayedFrom,
+        final String formType) {
+        return new DelayedSubmissionBusinessModel("345efg", "00000007", formType, "demo@ch.gov.uk",
+            delayedFrom.minusSeconds(5)
+                .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_BUSINESS_EMAIL_DATE_FORMAT)));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
@@ -10,6 +10,7 @@ import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelaye
 import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -92,6 +93,8 @@ class StandardServiceDelayedHandlerTest {
         when(submission.getConfirmationReference()).thenReturn("345efg");
         when(submission.getLastModifiedAt()).thenReturn(delayedFrom);
         when(submission.getSubmittedAt()).thenReturn(delayedFrom.minusSeconds(5));
+        when(submission.getPresenter()).thenReturn(new Presenter("email"));
+        when(submission.getCompany()).thenReturn(new Company("number", "name"));
 
         // when
         testHandler.buildAndSendEmails(submissions, NOW);
@@ -100,8 +103,10 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(
-                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+                    .atZone(ZoneId.of("Europe/London"))
+                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    submission.getPresenter().getEmail(),
+                    submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
         verifyNoMoreInteractions(emailService);
         verifyNoInteractions(formCategoryToEmailAddressService);
     }
@@ -116,6 +121,8 @@ class StandardServiceDelayedHandlerTest {
         when(submission.getConfirmationReference()).thenReturn("345efg");
         when(submission.getLastModifiedAt()).thenReturn(delayedFrom);
         when(submission.getCreatedAt()).thenReturn(delayedFrom.minusSeconds(5));
+        when(submission.getPresenter()).thenReturn(new Presenter("email"));
+        when(submission.getCompany()).thenReturn(new Company("number", "name"));
 
         // when
         testHandler.buildAndSendEmails(submissions, NOW);
@@ -124,8 +131,9 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(
-                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+                    .atZone(ZoneId.of("Europe/London"))
+                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    "email", "number")), SUPPORT_DELAY * 60));
         verifyNoMoreInteractions(emailService);
         verifyNoInteractions(formCategoryToEmailAddressService);
     }
@@ -154,12 +162,14 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(
-                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+                    .atZone(ZoneId.of("Europe/London"))
+                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    submission.getPresenter().getEmail(),
+                    submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
         verify(emailService).sendDelayedSubmissionBusinessEmail(
             new DelayedSubmissionBusinessEmailModel(
                 Collections.singletonList(createBusinessModel(delayedFrom, "CC01")), "cc@ch.gov.uk",
-                BUSINESS_DELAY));
+                BUSINESS_DELAY * 60));
         verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("CC01");
         verifyNoMoreInteractions(emailService, formCategoryToEmailAddressService);
     }
@@ -188,12 +198,14 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .format(
-                        DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT))))));
+                    .atZone(ZoneId.of("Europe/London"))
+                    .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                    submission.getPresenter().getEmail(),
+                    submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
         verify(emailService).sendDelayedSubmissionBusinessEmail(
             new DelayedSubmissionBusinessEmailModel(
                 Collections.singletonList(createBusinessModel(delayedFrom, "CC01")), "cc@ch.gov.uk",
-                BUSINESS_DELAY));
+                BUSINESS_DELAY * 60));
         verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("CC01");
         verifyNoMoreInteractions(emailService, formCategoryToEmailAddressService);
     }
@@ -227,19 +239,21 @@ class StandardServiceDelayedHandlerTest {
         // then
         final DelayedSubmissionSupportModel supportModel =
             new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)));
+                .atZone(ZoneId.of("Europe/London"))
+                .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
+                submission.getPresenter().getEmail(), submission.getCompany().getCompanyNumber());
 
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(
-                Arrays.asList(supportModel, supportModel, supportModel)));
+                Arrays.asList(supportModel, supportModel, supportModel), SUPPORT_DELAY * 60));
         verify(emailService).sendDelayedSubmissionBusinessEmail(
             new DelayedSubmissionBusinessEmailModel(
                 Arrays.asList(createBusinessModel(delayedFrom, "CC01"),
-                    createBusinessModel(delayedFrom, "CC03")), "cc@ch.gov.uk", BUSINESS_DELAY));
+                    createBusinessModel(delayedFrom, "CC03")), "cc@ch.gov.uk", BUSINESS_DELAY * 60));
         verify(emailService).sendDelayedSubmissionBusinessEmail(
             new DelayedSubmissionBusinessEmailModel(
                 Collections.singletonList(createBusinessModel(delayedFrom, "RP03")), "rp@ch.gov.uk",
-                BUSINESS_DELAY));
+                BUSINESS_DELAY * 60));
         verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("CC01");
         verify(formCategoryToEmailAddressService).getEmailAddressForFormCategory("RP03");
         verifyNoMoreInteractions(emailService, formCategoryToEmailAddressService);

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/StandardServiceDelayedHandlerTest.java
@@ -10,7 +10,6 @@ import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelaye
 import static uk.gov.companieshouse.efs.api.events.service.StandardServiceDelayedHandler.SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -103,7 +102,6 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .atZone(ZoneId.of("Europe/London"))
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
@@ -131,7 +129,6 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .atZone(ZoneId.of("Europe/London"))
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                     "email", "number")), SUPPORT_DELAY * 60));
         verifyNoMoreInteractions(emailService);
@@ -162,7 +159,6 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .atZone(ZoneId.of("Europe/London"))
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
@@ -198,7 +194,6 @@ class StandardServiceDelayedHandlerTest {
         verify(emailService).sendDelayedSubmissionSupportEmail(
             new DelayedSubmissionSupportEmailModel(Collections.singletonList(
                 new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                    .atZone(ZoneId.of("Europe/London"))
                     .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                     submission.getPresenter().getEmail(),
                     submission.getCompany().getCompanyNumber())), SUPPORT_DELAY * 60));
@@ -239,7 +234,6 @@ class StandardServiceDelayedHandlerTest {
         // then
         final DelayedSubmissionSupportModel supportModel =
             new DelayedSubmissionSupportModel("123abd", "345efg", delayedFrom.minusSeconds(5)
-                .atZone(ZoneId.of("Europe/London"))
                 .format(DateTimeFormatter.ofPattern(SUBMITTED_AT_SUPPORT_EMAIL_DATE_FORMAT)),
                 submission.getPresenter().getEmail(), submission.getCompany().getCompanyNumber());
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +30,7 @@ import uk.gov.companieshouse.efs.api.util.CurrentTimestampGenerator;
 class SubmissionRepositoryImplTest {
 
     private static final String ID = "_id";
+    private static final String FORM_TYPE = "form.form_type";
     private static final String FORM_BARCODE = "form.barcode";
     private static final String STATUS = "status";
     private static final String SUBMISSIONS_COLLECTION = "submissions";
@@ -180,20 +182,47 @@ class SubmissionRepositoryImplTest {
         repository.findDelayedSubmissions(SubmissionStatus.PROCESSING, now);
 
         //then
-        verify(template).find(
-            Query.query(Criteria.where("status").is(SubmissionStatus.PROCESSING).and("last_modified_at").lte(now)),
-            Submission.class, SUBMISSIONS_COLLECTION);
+        verify(template).find(Query.query(Criteria.where("status")
+            .is(SubmissionStatus.PROCESSING)
+            .and(LAST_MODIFIED_AT)
+            .lte(now)
+            .not()
+            .and(FORM_TYPE)
+            .regex("SAMEDAY$")), Submission.class, SUBMISSIONS_COLLECTION);
+    }
+
+    @Test
+    void findDelayedSameDaySubmissions() {
+        //given
+        LocalDateTime delayedFrom = LocalDateTime.now();
+        final EnumSet<SubmissionStatus> statuses =
+            EnumSet.of(SubmissionStatus.PROCESSING, SubmissionStatus.READY_TO_SUBMIT);
+
+        //when
+        repository.findDelayedSameDaySubmissions(statuses, delayedFrom);
+
+        //then
+        verify(template).find(Query.query(Criteria.where("status")
+            .in(statuses)
+            .and("submitted_at")
+            .lte(delayedFrom)
+            .and(FORM_TYPE)
+            .regex("SAMEDAY$")), Submission.class, SUBMISSIONS_COLLECTION);
     }
 
     @Test
     void findSuccessfulPaidSubmissions() {
         //when
-        repository.findPaidSubmissions(SubmissionRepositoryImpl.SUCCESSFUL_STATUSES, START_DATE, END_DATE);
+        repository.findPaidSubmissions(SubmissionRepositoryImpl.SUCCESSFUL_STATUSES, START_DATE,
+            END_DATE);
 
         //then
-        verify(template).find(Query.query(
-            Criteria.where(STATUS).in(SubmissionRepositoryImpl.SUCCESSFUL_STATUSES).and(SUBMITTED_AT)
-                .gte(START_DATE).lt(END_DATE).and(FEE_ON_SUBMISSION).exists(true)), Submission.class,
-            SUBMISSIONS_COLLECTION);
+        verify(template).find(Query.query(Criteria.where(STATUS)
+            .in(SubmissionRepositoryImpl.SUCCESSFUL_STATUSES)
+            .and(SUBMITTED_AT)
+            .gte(START_DATE)
+            .lt(END_DATE)
+            .and(FEE_ON_SUBMISSION)
+            .exists(true)), Submission.class, SUBMISSIONS_COLLECTION);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
@@ -186,9 +186,8 @@ class SubmissionRepositoryImplTest {
             .is(SubmissionStatus.PROCESSING)
             .and(LAST_MODIFIED_AT)
             .lte(now)
-            .not()
             .and(FORM_TYPE)
-            .is("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
+            .ne("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/repository/SubmissionRepositoryImplTest.java
@@ -188,7 +188,7 @@ class SubmissionRepositoryImplTest {
             .lte(now)
             .not()
             .and(FORM_TYPE)
-            .regex("SAMEDAY$")), Submission.class, SUBMISSIONS_COLLECTION);
+            .is("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
     }
 
     @Test
@@ -207,7 +207,7 @@ class SubmissionRepositoryImplTest {
             .and("submitted_at")
             .lte(delayedFrom)
             .and(FORM_TYPE)
-            .regex("SAMEDAY$")), Submission.class, SUBMISSIONS_COLLECTION);
+            .is("SH19_SAMEDAY")), Submission.class, SUBMISSIONS_COLLECTION);
     }
 
     @Test


### PR DESCRIPTION
- add query for delayed SH19_SAMEDAY forms
- refactor delayed email responsibility out of EventsServiceImpl
  using strategy pattern
- add delayed SH19_SAMEDAY email strategy
- increase test coverage
- use SH19 sameday email template for notification

Resolves:
BI-8232