### PR TITLE
Amend healthcheck url to be 'efs-submission-api/healthcheck'

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,9 @@
+# Spring Actuator
+management.endpoints.enabled-by-default=${MANAGEMENT_ENDPOINTS_ENABLED_BY_DEFAULT}
+management.endpoint.health.enabled=${MANAGEMENT_ENDPOINT_HEALTH_ENABLED}
+management.endpoints.web.path-mapping.health=${MANAGEMENT_ENDPOINTS_WEB_PATH_MAPPING_HEALTH}
+management.endpoints.web.base-path=${MANAGEMENT_ENDPOINTS_WEB_BASE_PATH}
+
 ref.pattern=${REF_PATTERN}
 ref.symbol-set=${REF_SYMBOL_SET}
 


### PR DESCRIPTION
Currently in tcats1 it's `https://internalapi.tcats1.aws.chdev.org/efs-submission-api/health`

Correct to `/efs-submission-api/healthcheck`

![Screenshot 2022-05-13 at 1 48 30 pm](https://user-images.githubusercontent.com/2736331/168286397-dc04006b-5890-4986-849b-e591323456d6.png)

BI-9879

Matches spec in https://github.com/companieshouse/styleguides/blob/main/health_check.md

These config values are already present in `chs-configs` and in live `app_env`