### PR TITLE
Add child order to form & category templates

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplate.java
@@ -2,12 +2,10 @@ package uk.gov.companieshouse.efs.api.categorytemplates.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.annotation.Id;
@@ -29,6 +27,10 @@ public class CategoryTemplate {
     @Id
     private String categoryType;
 
+    @JsonProperty("order_index")
+    @Field
+    private Integer orderIndex;
+
     @JsonProperty("category_name")
     @Field
     private String categoryName;
@@ -47,16 +49,19 @@ public class CategoryTemplate {
 
     /**
      * Constructor which sets the submission form category data.
-     * @param categoryType the category type
-     * @param categoryName the category name
-     * @param parent used when the category has a parent category
-     * @param categoryHint the category hint
+     *
+     * @param categoryType  the category type
+     * @param orderIndex    the ordering within the category
+     * @param categoryName  the category name
+     * @param parent        used when the category has a parent category
+     * @param categoryHint  the category hint
      * @param guidanceTexts a list of id's of guidance fragments to show on the category
-     *                               selection screen
+     *                      selection screen
      */
-    public CategoryTemplate(String categoryType, String categoryName, String parent,
-                            String categoryHint, final List<Integer> guidanceTexts) {
+    public CategoryTemplate(String categoryType, final Integer orderIndex, String categoryName,
+            String parent, String categoryHint, final List<Integer> guidanceTexts) {
         this.categoryType = categoryType;
+        this.orderIndex = orderIndex;
         this.categoryName = categoryName;
         this.parent = parent;
         this.categoryHint = categoryHint;
@@ -65,6 +70,10 @@ public class CategoryTemplate {
 
     public String getCategoryType() {
         return categoryType;
+    }
+
+    public Integer getOrderIndex() {
+        return orderIndex;
     }
 
     public String getCategoryName() {
@@ -97,23 +106,25 @@ public class CategoryTemplate {
             return false;
         }
         final CategoryTemplate that = (CategoryTemplate) o;
-        return Objects.equals(getCategoryType(), that.getCategoryType()) && Objects
-            .equals(getCategoryName(), that.getCategoryName()) && Objects
-                   .equals(getParent(), that.getParent()) && Objects
-                   .equals(getCategoryHint(), that.getCategoryHint()) && Objects
-                   .equals(getGuidanceTexts(), that.getGuidanceTexts());
+        return Objects.equals(getCategoryType(), that.getCategoryType()) &&
+                Objects.equals(getOrderIndex(), that.getOrderIndex()) &&
+                Objects.equals(getCategoryName(), that.getCategoryName()) &&
+                Objects.equals(getParent(), that.getParent()) &&
+                Objects.equals(getCategoryHint(), that.getCategoryHint()) &&
+                Objects.equals(getGuidanceTexts(), that.getGuidanceTexts());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getCategoryType(), getCategoryName(), getParent(), getCategoryHint(),
-                getGuidanceTexts());
+        return Objects.hash(getCategoryType(), getOrderIndex(), getCategoryName(), getParent(),
+                getCategoryHint(), getGuidanceTexts());
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
                 .append("categoryType", getCategoryType())
+                .append("orderIndex", getOrderIndex())
                 .append("categoryName", getCategoryName())
                 .append("parent", getParent())
                 .append("categoryHint", getCategoryHint())

--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/repository/CategoryTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/repository/CategoryTemplateRepository.java
@@ -11,8 +11,9 @@ public interface CategoryTemplateRepository extends MongoRepository<CategoryTemp
 
     /**
      * Finds all form categories by parent category.
+     * Applies ordering by optional property 'orderIndex'.
      *
      * @return List&lt;CategoryTemplate&gt;
      */
-    List<CategoryTemplate> findByParent(String category);
+    List<CategoryTemplate> findByParentOrderByOrderIndex(String category);
 }               

--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImpl.java
@@ -50,7 +50,7 @@ public class CategoryTemplateServiceImpl implements CategoryTemplateService {
 
     @Override
     public CategoryTemplateListApi getCategoryTemplatesByCategory(final String id) {
-        final List<CategoryTemplate> byParent = repository.findByParent(id);
+        final List<CategoryTemplate> byParent = repository.findByParentOrderByOrderIndex(id);
         return mapper.map(byParent);
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplate.java
@@ -37,6 +37,10 @@ public class FormTemplate {
     @Id
     private String formType;
 
+    @JsonProperty("order_index")
+    @Field
+    private Integer orderIndex;
+
     @JsonProperty("form_name")
     @Field
     private String formName;
@@ -71,6 +75,10 @@ public class FormTemplate {
 
     public String getFormType() {
         return formType;
+    }
+
+    public Integer getOrderIndex() {
+        return orderIndex;
     }
 
     public String getFormName() {
@@ -114,26 +122,30 @@ public class FormTemplate {
             return false;
         }
         final FormTemplate that = (FormTemplate) o;
-        return isAuthenticationRequired() == that.isAuthenticationRequired()
-            && isFesEnabled() == that.isFesEnabled() && isSameDay() == that.isSameDay()
-            && Objects.equals(getFormType(), that.getFormType()) && Objects.equals(getFormName(),
-            that.getFormName()) && Objects.equals(getFormCategory(), that.getFormCategory())
-            && Objects.equals(getFee(), that.getFee()) && Objects.equals(getFesDocType(),
-            that.getFesDocType()) && Objects.equals(getMessageTextIdList(),
-            that.getMessageTextIdList());
+        return isAuthenticationRequired() == that.isAuthenticationRequired() &&
+                isFesEnabled() == that.isFesEnabled() &&
+                isSameDay() == that.isSameDay() &&
+                Objects.equals(getFormType(), that.getFormType()) &&
+                Objects.equals(getOrderIndex(), that.getOrderIndex()) &&
+                Objects.equals(getFormName(), that.getFormName()) &&
+                Objects.equals(getFormCategory(), that.getFormCategory()) &&
+                Objects.equals(getFee(), that.getFee()) &&
+                Objects.equals(getFesDocType(), that.getFesDocType()) &&
+                Objects.equals(getMessageTextIdList(), that.getMessageTextIdList());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getFormType(), getFormName(), getFormCategory(), getFee(),
-            isAuthenticationRequired(), isFesEnabled(), getFesDocType(), isSameDay(),
-            getMessageTextIdList());
+        return Objects.hash(getFormType(), getOrderIndex(), getFormName(), getFormCategory(),
+                getFee(), isAuthenticationRequired(), isFesEnabled(), getFesDocType(), isSameDay(),
+                getMessageTextIdList());
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
                 .append("formType", getFormType())
+                .append("orderIndex", getOrderIndex())
                 .append("formName", getFormName())
                 .append("formCategory", getFormCategory())
                 .append("fee", getFee())
@@ -158,6 +170,11 @@ public class FormTemplate {
         
         public FormTemplate.Builder withFormType(final String formType) {
             buildSteps.add(data -> data.formType = formType);
+            return this;
+        }
+
+        public FormTemplate.Builder withOrderIndex(final Integer orderIndex) {
+            buildSteps.add(data -> data.orderIndex = orderIndex);
             return this;
         }
         

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/repository/FormTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/repository/FormTemplateRepository.java
@@ -11,10 +11,11 @@ public interface FormTemplateRepository extends MongoRepository<FormTemplate, St
 
     /**
      * Finds all form template details by category.
+     * Applies ordering by optional property 'orderIndex'.
      *
      * @return List&lt;FormTemplate&gt;
      */
-    List<FormTemplate> findByFormCategory(String category);
+    List<FormTemplate> findByFormCategoryOrderByOrderIndex(String category);
 
 }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImpl.java
@@ -46,7 +46,7 @@ public class FormTemplateServiceImpl implements FormTemplateService {
 
     @Override
     public FormTemplateListApi getFormTemplatesByCategory(final String id) {
-        final List<FormTemplate> byCategory = repository.findByFormCategory(id);
+        final List<FormTemplate> byCategory = repository.findByFormCategoryOrderByOrderIndex(id);
         return mapper.map(byCategory);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/mapper/CategoryTemplateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/mapper/CategoryTemplateMapperTest.java
@@ -45,19 +45,23 @@ class CategoryTemplateMapperTest {
     }
 
     private CategoryTemplate getCategory() {
-        return new CategoryTemplate("MA", "New Incorporation",
-                "", "", null);
+        final CategoryTemplate category =
+                new CategoryTemplate("MA", 1, "New Incorporation", "", "", null);
+
+        category.setGuidanceTexts(Collections.singletonList(3000));
+
+        return category;
     }
 
     private CategoryTemplateListApi expectedList() {
         CategoryTemplateApi element = new CategoryTemplateApi("MA", "New Incorporation", "", "",
-                Collections.emptyList());
+                Collections.singletonList(3000));
         return new CategoryTemplateListApi(Collections.singletonList(element));
     }
 
     private CategoryTemplateApi expectedSingle() {
         CategoryTemplateApi element = new CategoryTemplateApi("MA", "New Incorporation", "", "",
-                Collections.emptyList());
+                Collections.singletonList(3000));
         return new CategoryTemplateApi(element);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/model/CategoryTemplateTest.java
@@ -21,8 +21,7 @@ class CategoryTemplateTest {
 
     @BeforeEach
     void setUp() {
-        testCategoryTemplate = new CategoryTemplate("CC01",
-                "Category01", "", "", null);
+        testCategoryTemplate = new CategoryTemplate("CC01", 5, "Category01", "", "", null);
         JacksonTester.initFields(this, new ObjectMapper());
     }
 
@@ -30,6 +29,7 @@ class CategoryTemplateTest {
     void categoryTemplate() {
 
         assertThat(testCategoryTemplate.getCategoryType(), is("CC01"));
+        assertThat(testCategoryTemplate.getOrderIndex(), is(5));
         assertThat(testCategoryTemplate.getCategoryName(), is("Category01"));
         assertThat(testCategoryTemplate.getParent(), is(""));
         assertThat(testCategoryTemplate.getCategoryHint(), is(""));
@@ -45,7 +45,7 @@ class CategoryTemplateTest {
     void toStringTest() {
         assertThat(testCategoryTemplate.toString(), Matchers.is(
                 //@formatter:off
-                "CategoryTemplate[categoryType=CC01,categoryName=Category01,parent=,categoryHint=,guidanceTexts=[]]"
+                "CategoryTemplate[categoryType=CC01,orderIndex=5,categoryName=Category01,parent=,categoryHint=,guidanceTexts=[]]"
                 //@formatter:on
         ));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/categorytemplates/service/CategoryTemplateServiceImplTest.java
@@ -79,7 +79,7 @@ class CategoryTemplateServiceImplTest {
 
         //given
         String categoryId = "CC01";
-        CategoryTemplate category = new CategoryTemplate(categoryId, "CatCat", null, null, null);
+        CategoryTemplate category = new CategoryTemplate(categoryId, 1, "CatCat", null, null, null);
         CategoryTemplateApi mappedCategory = new CategoryTemplateApi(categoryId, "CatCat", null, null, null);
 
         when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
@@ -112,12 +112,13 @@ class CategoryTemplateServiceImplTest {
 
         //given
         String categoryId = "CC01";
-        CategoryTemplate mappedCategory = new CategoryTemplate(categoryId, "CatCat", null, null, null);
+        CategoryTemplate mappedCategory = new CategoryTemplate(categoryId, 1, "CatCat", null, null,
+                null);
 
         List<CategoryTemplate> listCategory = new ArrayList<>();
         listCategory.add(mappedCategory);
 
-        when(categoryRepository.findByParent(categoryId)).thenReturn(listCategory);
+        when(categoryRepository.findByParentOrderByOrderIndex(categoryId)).thenReturn(listCategory);
         when(mapper.map(anyList())).thenReturn(categoryList);
 
         //when
@@ -157,7 +158,7 @@ class CategoryTemplateServiceImplTest {
     void getTopLevelCategoryWhenParentIsSelf() {
         // given
         final CategoryTemplate category =
-            new CategoryTemplate("SELF_PARENT", "parent is self", "SELF_PARENT", null, null);
+            new CategoryTemplate("SELF_PARENT", 0, "parent is self", "SELF_PARENT", null, null);
 
         when(categoryRepository.findById(category.getCategoryType())).thenReturn(
             Optional.of(category));

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/model/FormTemplateTest.java
@@ -24,6 +24,7 @@ class FormTemplateTest {
     void setUp() {
         testFormTemplate = FormTemplate.builder()
             .withFormType("CC01")
+            .withOrderIndex(1)
             .withFormName("Form01")
             .withFormCategory("CC")
             .withFee("100")
@@ -40,6 +41,7 @@ class FormTemplateTest {
     void formTemplate() {
 
         assertThat(testFormTemplate.getFormType(), is("CC01"));
+        assertThat(testFormTemplate.getOrderIndex(), is(1));
         assertThat(testFormTemplate.getFormName(), is("Form01"));
         assertThat(testFormTemplate.getFormCategory(), is("CC"));
         assertThat(testFormTemplate.getFee(), is("100"));
@@ -59,7 +61,7 @@ class FormTemplateTest {
     void toStringTest() {
         assertThat(testFormTemplate.toString(), Matchers.is(
                 //@formatter:off
-                "FormTemplate[formType=CC01,formName=Form01,formCategory=CC,fee=100,"
+                "FormTemplate[formType=CC01,orderIndex=1,formName=Form01,formCategory=CC,fee=100,"
                     + "isAuthenticationRequired=true,isFesEnabled=true,fesDocType=FES," 
                     + "sameDay=true,messageTextIdList=[1, 2, 3]]"
                 //@formatter:on

--- a/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/formtemplates/service/FormTemplateServiceImplTest.java
@@ -125,7 +125,7 @@ class FormTemplateServiceImplTest {
         List<FormTemplate> listForm = new ArrayList<>();
         listForm.add(mappedForm);
 
-        when(formRepository.findByFormCategory(categoryId)).thenReturn(listForm);
+        when(formRepository.findByFormCategoryOrderByOrderIndex(categoryId)).thenReturn(listForm);
         when(mapper.map(anyList())).thenReturn(formList);
 
         //when


### PR DESCRIPTION
Apply sorting to repository methods fetching Form and Category templates belonging to a parent category using the new optional integer property 'orderIndex'

- Templates without an 'orderIndex' value will sort before those with one.
- Templates sort by orderIndex in ascending order

Summary of which API endpoints for form & category templates are enhanced to order the response data if orderIndex values are provided in the database:

| API Endpoint | Ordering within Parent |
|--------------|------------------|
| `/form-templates` | ⚪ No |
| `/form-template/{form-id}` | ⚪ No |
| `/form-templates?category={category-id}` | ✅ Yes |
| `/category-templates` | ⚪ No |
| `/category-template/{category-id}` | ⚪ No |
| `/category-template/` | ⚪ No |
| `/category-templates?parent={category-id}` | ✅ Yes |