### PR TITLE
Replace version of 'queryForObject' method

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerContext.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/DelayedSubmissionHandlerContext.java
@@ -23,7 +23,7 @@ public class DelayedSubmissionHandlerContext {
         final Set<DelayedSubmissionHandlerStrategy> implementationSet,
         final Logger logger) {
         this.logger = logger;
-        implementationSet.forEach(s -> logger.info(s.getServiceLevel() + "," + s));
+        implementationSet.forEach(s -> this.logger.info(s.getServiceLevel() + "," + s));
         this.strategyImplementations = implementationSet.stream()
             .collect(Collectors.toMap(DelayedSubmissionHandlerStrategy::getServiceLevel,
                 Function.identity()));

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/fesloader/BatchDao.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/fesloader/BatchDao.java
@@ -22,8 +22,8 @@ public class BatchDao {
     }
 
     public long getBatchNameId(String batchNamePrefix) {
-        return jdbc.queryForObject("SELECT fes_common_pkg.F_GETNEXTREFID(?, ?) from DUAL",
-                new Object[] { batchNamePrefix, 16 }, Long.class);
+        return jdbc.queryForObject("SELECT fes_common_pkg.F_GETNEXTREFID(?, ?) from DUAL", Long.class,
+                batchNamePrefix, 16);
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/fesloader/BatchDaoTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/fesloader/BatchDaoTest.java
@@ -49,7 +49,7 @@ class BatchDaoTest {
     @Test
     void testBatchDaoObtainsNextBatchNameIdFromSequence() {
         //given
-        when(this.template.queryForObject(anyString(), any(), eq(Long.class))).thenReturn(BATCH_NAME_ID);
+        when(this.template.queryForObject(anyString(), eq(Long.class), any())).thenReturn(BATCH_NAME_ID);
 
         //when
         long actual = this.batchDao.getBatchNameId("EFS_200511");


### PR DESCRIPTION
Fix for deprecated 'queryForObject' method as per
https://stackoverflow.com/questions/65301011/jdbctemplate-queryforobject-and-query-is-deprecated-in-spring-what-should-i

I have tested that form sent to FES and batch name was generated as expected `EFS_220628_0001` and `EFS_220628_0002`

BI-8133