### PR TITLE
EFS API: Add support from payment template activation dates

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -37,7 +37,7 @@ local_resource(
   ],
   cmd = '''
     root=$(basename "$(cd ../..|| exit; pwd)")
-    container_name="${root}_mongo_1"
+    container_name="${root}-mongo-1"
 
     json_files=(src/main/resources/*.json)
     db="efs_submissions"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 
 services:
-  suppression-web:
+  efs-submission-api:
     image: '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/efs-submission-api:latest'
     expose:
       - 8080

--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.1</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,26 @@
         </dependency>
     </dependencies>
     <build>
+        <!--
+            Workaround for Tilt infinite rebuild loop:
+            1. mvn compile: copies src/main/resources/*.properties to target/classes (standard behaviour)
+            2. those copies files have a new ctime (creation timestamp)
+            3. Tiltfile.dev watches ./target/classes/*.properties and triggers live update
+            4. Live update runs mvn compile
+
+            Solution:
+            1. Prevent step 1 above by excluding src/main/resources/*.properties from standard build
+            2. Instead run maven-antrun-plugin copy task setting preservelastmodified=true
+        -->
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>*.properties</exclude>
+                </excludes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -346,6 +366,28 @@
                     </includes>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
+            </plugin>
+            <!-- See Workaround Note above -->
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <configuration>
+                            <target>
+                                <copy todir="${project.build.outputDirectory}" preservelastmodified="true">
+                                    <fileset dir="src/main/resources">
+                                        <include name="*.properties"/>
+                                    </fileset>
+                                </copy>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/src/it/java/uk/gov/companieshouse/efs/api/payment/controller/MongoDbTestContainerConfig.java
+++ b/src/it/java/uk/gov/companieshouse/efs/api/payment/controller/MongoDbTestContainerConfig.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.efs.api.payment.controller;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+@Configuration
+@EnableMongoRepositories
+public class MongoDbTestContainerConfig {
+    @Container
+    public static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5")
+        .withExposedPorts(27017);
+
+    static {
+        mongoDBContainer.start();
+
+        Integer mappedPort = mongoDBContainer.getMappedPort(27017);
+
+        System.setProperty("mongodb.container.port", String.valueOf(mappedPort));
+    }
+}

--- a/src/it/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerDatabaseIT.java
+++ b/src/it/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerDatabaseIT.java
@@ -1,0 +1,107 @@
+package uk.gov.companieshouse.efs.api.payment.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
+import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateId;
+import uk.gov.companieshouse.efs.api.payment.repository.PaymentTemplateRepository;
+
+@DataMongoTest
+@EnableMongoRepositories("uk.gov.companieshouse.efs.api.payment.repository")
+@Testcontainers(disabledWithoutDocker = true)
+@ContextConfiguration(classes = MongoDbTestContainerConfig.class)
+class PaymentControllerDatabaseIT {
+    private static final String FEE_ID = "FEE";
+    private static final LocalDateTime NOW_LDT = LocalDateTime.now();
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+    @Autowired
+    private PaymentTemplateRepository paymentTemplateRepository;
+    private PaymentTemplate past;
+    private PaymentTemplate present;
+    private PaymentTemplate future;
+
+    @BeforeEach
+    void setUp() {
+        past = createPaymentTemplate(FEE_ID, NOW_LDT.minusSeconds(1), "past");
+        present = createPaymentTemplate(FEE_ID, NOW_LDT, "present");
+        future = createPaymentTemplate(FEE_ID, NOW_LDT.plusHours(1),
+            "future");
+        mongoTemplate.save(past);
+        mongoTemplate.save(present);
+        mongoTemplate.save(future);
+
+    }
+
+    @Test
+    void findByFeeWhenNoneExistThenEmptyList() {
+        final List<PaymentTemplate> result =
+            paymentTemplateRepository.findById_FeeOrderById_ActiveFromDesc(
+                "no-such-fee");
+
+        assertThat(result, is(empty()));
+    }
+
+    @Test
+    void findByFeeWhenManyExistThenListAllNewestFirst() {
+        final List<PaymentTemplate> result =
+            paymentTemplateRepository.findById_FeeOrderById_ActiveFromDesc(
+                FEE_ID);
+
+        assertThat(result, contains(future, present, past));
+    }
+
+    @Test
+    void findFirstByFeeWhenNoneExistThenEmptyOptional() {
+        final Optional<PaymentTemplate> result =
+            paymentTemplateRepository.findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
+                "no-such-fee", NOW_LDT);
+
+        assertThat(result, is(Optional.empty()));
+
+    }
+
+    @Test
+    void findByFirstFeeWhenManyExistThenMostRecentNotInFuture() {
+        final Optional<PaymentTemplate> result =
+            paymentTemplateRepository.findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
+                FEE_ID, NOW_LDT);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getItems().get(0).getAmount(), is("present"));
+    }
+
+    @Test
+    void findByFirstFeeWhenOnlyFutureExistThenEmptyOptional() {
+        mongoTemplate.save(createPaymentTemplate("FUTURE_FEE", NOW_LDT.plusSeconds(1), "future"));
+
+        final Optional<PaymentTemplate> result =
+            paymentTemplateRepository.findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
+                "FUTURE_FEE", NOW_LDT);
+
+        assertThat(result, is(Optional.empty()));
+    }
+
+    private PaymentTemplate createPaymentTemplate(final String feeId,
+        final LocalDateTime activeFrom, final String amount) {
+        return PaymentTemplate.newBuilder()
+            .withId(new PaymentTemplateId(feeId, activeFrom))
+            .withItem(PaymentTemplate.Item.newBuilder().withAmount(amount).build())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateController.java
@@ -31,6 +31,7 @@ public class CategoryTemplateController {
     /**
      * Category template controller constructor.
      * @param categoryService service used to store the category template
+     * @param logger the service logger
      */
     @Autowired
     public CategoryTemplateController(final CategoryTemplateService categoryService, final Logger logger) {
@@ -39,8 +40,8 @@ public class CategoryTemplateController {
     }
 
     /**
-     * Returns a responseEntity which contains a list of category types belonging to an optional parent form
-     * category, or all categories if omitted.
+     * Returns a responseEntity which contains a list of category types belonging to an optional
+     * parent form category, or all categories if omitted.
      * Will return a status of not found if the list is not found.
      *
      * @return responseEntity

--- a/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/categorytemplates/controller/CategoryTemplateController.java
@@ -22,8 +22,7 @@ import uk.gov.companieshouse.logging.Logger;
  */
 @RestController
 @ResponseStatus(HttpStatus.OK)
-@RequestMapping(value = "/efs-submission-api", produces = {"application/json"},
-        consumes = {"application/json"})
+@RequestMapping("/efs-submission-api")
 public class CategoryTemplateController {
 
     private CategoryTemplateService categoryService;
@@ -46,7 +45,7 @@ public class CategoryTemplateController {
      *
      * @return responseEntity
      */
-    @GetMapping(value = "/category-templates")
+    @GetMapping(value = "/category-templates", produces = {"application/json"})
     public ResponseEntity<CategoryTemplateListApi> getCategoryTemplates(
         @RequestParam(value = "parent", required = false) String categoryId, final HttpServletRequest request) {
 
@@ -70,7 +69,7 @@ public class CategoryTemplateController {
      *
      * @return responseEntity
      */
-    @GetMapping(value = "/category-template/{id}")
+    @GetMapping(value = "/category-template/{id}", produces = {"application/json"})
     public ResponseEntity<CategoryTemplateApi> getCategoryTemplate(@PathVariable String id, HttpServletRequest request) {
         try {
             return ResponseEntity.ok().body(categoryService.getCategoryTemplate(id));
@@ -83,7 +82,7 @@ public class CategoryTemplateController {
         }
     }
 
-    @GetMapping(value = "/category-template/")
+    @GetMapping(value = "/category-template/", produces = {"application/json"})
     public ResponseEntity<CategoryTemplateApi> getRootCategory(HttpServletRequest request) {
         final String id = "ROOT";
         return getCategoryTemplate(id, request);

--- a/src/main/java/uk/gov/companieshouse/efs/api/companyauthallowlist/controller/CompanyAuthAllowListController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/companyauthallowlist/controller/CompanyAuthAllowListController.java
@@ -16,11 +16,7 @@ import uk.gov.companieshouse.logging.Logger;
  */
 @RestController
 @ResponseStatus(HttpStatus.OK)
-@RequestMapping(
-        value = "/efs-submission-api",
-        produces = {"application/json"},
-        consumes = {"application/json"}
-)
+@RequestMapping("/efs-submission-api")
 public class CompanyAuthAllowListController {
 
     private final Logger logger;
@@ -42,7 +38,8 @@ public class CompanyAuthAllowListController {
      * Returns a responseEntity which contains a Boolean value.
      * @return responseEntity containing the response.
      */
-    @GetMapping(value = "/company-authentication/allow-list/{emailAddress}")
+    @GetMapping(value = "/company-authentication/allow-list/{emailAddress}",
+        produces = {"application/json"})
     public ResponseEntity<Boolean> getIsOnAllowList(@PathVariable String emailAddress) {
         try {
             return ResponseEntity.ok().body(service.isOnAllowList(emailAddress));

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateController.java
@@ -21,8 +21,7 @@ import uk.gov.companieshouse.logging.Logger;
  */
 @RestController
 @ResponseStatus(HttpStatus.OK)
-@RequestMapping(value = "/efs-submission-api", produces = {"application/json"},
-        consumes = {"application/json"})
+@RequestMapping("/efs-submission-api")
 public class FormTemplateController {
 
     private FormTemplateService formService;
@@ -45,7 +44,7 @@ public class FormTemplateController {
      *
      * @return responseEntity
      */
-    @GetMapping(value = "/form-templates")
+    @GetMapping(value = "/form-templates", produces = {"application/json"})
     public ResponseEntity<FormTemplateListApi> getFormTemplates(
         @RequestParam(value = "category", required = false) String categoryId, HttpServletRequest request) {
 
@@ -69,7 +68,7 @@ public class FormTemplateController {
      *
      * @return responseEntity
      */
-    @GetMapping(value = "/form-template")
+    @GetMapping(value = "/form-template", produces = {"application/json"})
     public ResponseEntity<FormTemplateApi> getFormTemplate(@RequestParam("type") String id,
         HttpServletRequest request) {
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/formtemplates/controller/FormTemplateController.java
@@ -30,6 +30,7 @@ public class FormTemplateController {
     /**
      * Form template controller constructor.
      * @param formService service used to store the form template
+     * @param logger the service logger
      */
     @Autowired
     public FormTemplateController(final FormTemplateService formService, final Logger logger) {
@@ -38,8 +39,8 @@ public class FormTemplateController {
     }
 
     /**
-     * Returns a responseEntity which contains a list of form templates belonging to an optional form category, or
-     * all templates if category is omitted.
+     * Returns a responseEntity which contains a list of form templates belonging to an optional
+     * form category, or all templates if category is omitted.
      * Will return a status of not found if the category is not found.
      *
      * @return responseEntity

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
@@ -103,15 +103,14 @@ public class PaymentController {
 
                 logger.debug(MessageFormat.format("Fetching payment charge with id: {0}", chargeTemplateId));
                 if (StringUtils.isNotBlank(chargeTemplateId)) {
-                    //FIXME final Optional<PaymentTemplate> optionalTemplate =
-                        //paymentTemplateService.getTemplate(chargeTemplateId);
+                    final Optional<PaymentTemplate> optionalTemplate =
+                        paymentTemplateService.getTemplate(chargeTemplateId, null);
 
-//                    optionalTemplate.ifPresent(t -> logger.debug(MessageFormat.format("template={0}", t)));
-//                    response = optionalTemplate
-//                        .map(paymentTemplate -> getPaymentTemplateResponse(id, request, paymentTemplate))
-//                        .orElseGet(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)::build);
-                   // return response;
-                    return null;
+                    optionalTemplate.ifPresent(t -> logger.debug(MessageFormat.format("template={0}", t)));
+                    response = optionalTemplate
+                        .map(paymentTemplate -> getPaymentTemplateResponse(id, request, paymentTemplate))
+                        .orElseGet(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)::build);
+                    return response;
                 } else {
                     response = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
                 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
@@ -103,14 +103,15 @@ public class PaymentController {
 
                 logger.debug(MessageFormat.format("Fetching payment charge with id: {0}", chargeTemplateId));
                 if (StringUtils.isNotBlank(chargeTemplateId)) {
-                    final Optional<PaymentTemplate> optionalTemplate =
-                        paymentTemplateService.getTemplate(chargeTemplateId);
+                    //FIXME final Optional<PaymentTemplate> optionalTemplate =
+                        //paymentTemplateService.getTemplate(chargeTemplateId);
 
-                    optionalTemplate.ifPresent(t -> logger.debug(MessageFormat.format("template={0}", t)));
-                    response = optionalTemplate
-                        .map(paymentTemplate -> getPaymentTemplateResponse(id, request, paymentTemplate))
-                        .orElseGet(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)::build);
-                    return response;
+//                    optionalTemplate.ifPresent(t -> logger.debug(MessageFormat.format("template={0}", t)));
+//                    response = optionalTemplate
+//                        .map(paymentTemplate -> getPaymentTemplateResponse(id, request, paymentTemplate))
+//                        .orElseGet(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)::build);
+                   // return response;
+                    return null;
                 } else {
                     response = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
                 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
@@ -108,7 +108,7 @@ public class PaymentController {
                     chargeTemplateId, now));
                 if (StringUtils.isNotBlank(chargeTemplateId)) {
                     final Optional<PaymentTemplate> optionalTemplate =
-                        paymentTemplateService.getTemplate(chargeTemplateId, now);
+                        paymentTemplateService.getPaymentTemplate(chargeTemplateId, now);
 
                     optionalTemplate.ifPresent(t -> logger.debug(MessageFormat.format("template={0}", t)));
                     response = optionalTemplate

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
@@ -7,6 +7,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.MessageFormat;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -50,25 +52,25 @@ public class PaymentController {
         Sets.immutableEnumSet(SubmissionStatus.OPEN, SubmissionStatus.PAYMENT_REQUIRED);
 
     private final Logger logger;
+    private final Clock clock;
 
-    private final SubmissionService service;
+    private final SubmissionService submissionService;
     private final FormTemplateService formTemplateService;
     private final PaymentTemplateService paymentTemplateService;
-    private final SubmissionService submissionService;
     private final EmailService emailService;
     private final SubmissionApiMapper submissionApiMapper;
 
     @Autowired
-    public PaymentController(SubmissionService service, FormTemplateService formTemplateService,
-        final PaymentTemplateService paymentTemplateService,
-        final SubmissionService submissionService, final EmailService emailService,
-        final SubmissionApiMapper submissionApiMapper, Logger logger) {
-        this.service = service;
+    public PaymentController(final SubmissionService submissionService,
+        final FormTemplateService formTemplateService,
+        final PaymentTemplateService paymentTemplateService, final EmailService emailService,
+        final SubmissionApiMapper submissionApiMapper, final Clock clock, final Logger logger) {
         this.formTemplateService = formTemplateService;
         this.paymentTemplateService = paymentTemplateService;
         this.submissionService = submissionService;
         this.emailService = emailService;
         this.submissionApiMapper = submissionApiMapper;
+        this.clock = clock;
         this.logger = logger;
     }
 
@@ -85,7 +87,7 @@ public class PaymentController {
 
         logger.debug(MessageFormat.format("Fetching submission with id: {0}", id));
 
-        final SubmissionApi submission = service.readSubmission(id);
+        final SubmissionApi submission = submissionService.readSubmission(id);
         final ResponseEntity<PaymentTemplate> response;
 
         if (submission == null) {
@@ -104,7 +106,7 @@ public class PaymentController {
                 logger.debug(MessageFormat.format("Fetching payment charge with id: {0}", chargeTemplateId));
                 if (StringUtils.isNotBlank(chargeTemplateId)) {
                     final Optional<PaymentTemplate> optionalTemplate =
-                        paymentTemplateService.getTemplate(chargeTemplateId, null);
+                        paymentTemplateService.getTemplate(chargeTemplateId, LocalDateTime.now(clock));
 
                     optionalTemplate.ifPresent(t -> logger.debug(MessageFormat.format("template={0}", t)));
                     response = optionalTemplate
@@ -144,7 +146,7 @@ public class PaymentController {
         
         logger.debug(MessageFormat.format("Fetching submission with id: {0}", id));
 
-        final SubmissionApi submission = service.readSubmission(id);
+        final SubmissionApi submission = submissionService.readSubmission(id);
         ResponseEntity<SubmissionResponseApi> response = ResponseEntity.noContent()
             .build();
 
@@ -179,7 +181,7 @@ public class PaymentController {
     private ResponseEntity<PaymentTemplate> getPaymentTemplateResponse(final String id,
         final HttpServletRequest request, final PaymentTemplate paymentTemplate) {
         final ResponseEntity<PaymentTemplate> response;
-        final SubmissionApi submission = service.readSubmission(id);
+        final SubmissionApi submission = submissionService.readSubmission(id);
 
         if (submission.getCompany() == null || StringUtils.isBlank(submission.getCompany().getCompanyNumber())) {
             response = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
@@ -230,7 +232,8 @@ public class PaymentController {
         }
 
         try {
-            return ResponseEntity.ok(service.updateSubmissionWithPaymentSessions(id, paymentSessions));
+            return ResponseEntity.ok(
+                submissionService.updateSubmissionWithPaymentSessions(id, paymentSessions));
         } catch (SubmissionNotFoundException ex) {
             return ResponseEntity.notFound().build();
         } catch (SubmissionIncorrectStateException ex) {

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentController.java
@@ -102,11 +102,13 @@ public class PaymentController {
             FormTemplateApi formTemplate = formTemplateService.getFormTemplate(formType);
             if (formTemplate != null) {
                 final String chargeTemplateId = formTemplate.getPaymentCharge();
+                final LocalDateTime now = LocalDateTime.now(clock);
 
-                logger.debug(MessageFormat.format("Fetching payment charge with id: {0}", chargeTemplateId));
+                logger.debug(MessageFormat.format("Fetching template for fee: {0} at {1}",
+                    chargeTemplateId, now));
                 if (StringUtils.isNotBlank(chargeTemplateId)) {
                     final Optional<PaymentTemplate> optionalTemplate =
-                        paymentTemplateService.getTemplate(chargeTemplateId, LocalDateTime.now(clock));
+                        paymentTemplateService.getTemplate(chargeTemplateId, now);
 
                     optionalTemplate.ifPresent(t -> logger.debug(MessageFormat.format("template={0}", t)));
                     response = optionalTemplate

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerSpike.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerSpike.java
@@ -1,0 +1,84 @@
+package uk.gov.companieshouse.efs.api.payment.controller;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
+import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateId;
+import uk.gov.companieshouse.efs.api.payment.service.PaymentTemplateService;
+import uk.gov.companieshouse.logging.Logger;
+
+@RestController
+@ResponseStatus(HttpStatus.OK)
+@RequestMapping(value = "/efs-submission-api/payment-templates", produces = {"application/json"})
+
+public class PaymentControllerSpike {
+    private static final Instant CHARGE_TIMESTAMP = Instant.parse("2019-01-08T00:00:00.000Z");
+    private final Logger logger;
+    private final PaymentTemplateService paymentTemplateService;
+
+    @Autowired
+    public PaymentControllerSpike(final PaymentTemplateService paymentTemplateService,
+            Logger logger) {
+        this.paymentTemplateService = paymentTemplateService;
+        this.logger = logger;
+    }
+
+    /**
+     * Returns a responseEntity which contains a list of payment templates belonging to an optional
+     * form category, or all templates if category is omitted. Will return a status of not found if
+     * the category is not found.
+     *
+     * @return responseEntity
+     */
+    @GetMapping
+    public ResponseEntity<PaymentTemplate> getPaymentTemplates(
+            @RequestParam(value = "type") String id, HttpServletRequest request) {
+
+        Map<String, Object> info = new HashMap<>();
+        info.put("id", id);
+        info.put("chargedAt", CHARGE_TIMESTAMP);
+        logger.info("Payment template request for ", info);
+
+        try {
+            final Optional<PaymentTemplate> template =
+                    paymentTemplateService.getTemplate(id, CHARGE_TIMESTAMP);
+
+            logger.info("Payment template retrieved " + template.map(PaymentTemplate::getId)
+                    .map(PaymentTemplateId::getFee)
+                    .orElse("nothing found"));
+
+            return ResponseEntity.of(template);
+        }
+        catch (Exception ex) {
+
+            logger.error("Failed to get payment templates", ex, info);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .build();
+        }
+    }
+
+
+    @GetMapping("/test")
+    public ResponseEntity<Void> createTestPaymentTemplate() {
+
+        PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder()
+                .withId(new PaymentTemplateId("TEST", Instant.now()))
+                .withDescription("Testing")
+                .build();
+
+        paymentTemplateService.putTemplate(paymentTemplate);
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerSpike.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerSpike.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.payment.controller;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -23,7 +24,7 @@ import uk.gov.companieshouse.logging.Logger;
 @RequestMapping(value = "/efs-submission-api/payment-templates", produces = {"application/json"})
 
 public class PaymentControllerSpike {
-    private static final Instant CHARGE_TIMESTAMP = Instant.parse("2019-01-08T00:00:00.000Z");
+    private static final LocalDateTime CHARGE_TIMESTAMP = LocalDateTime.parse("2019-01-08T00:00:00");
     private final Logger logger;
     private final PaymentTemplateService paymentTemplateService;
 
@@ -73,7 +74,7 @@ public class PaymentControllerSpike {
     public ResponseEntity<Void> createTestPaymentTemplate() {
 
         PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder()
-                .withId(new PaymentTemplateId("TEST", Instant.now()))
+                .withId(new PaymentTemplateId("TEST", LocalDateTime.now()))
                 .withDescription("Testing")
                 .build();
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentFeatureTestingFeesController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentFeatureTestingFeesController.java
@@ -29,6 +29,10 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateId;
 import uk.gov.companieshouse.efs.api.payment.service.PaymentTemplateService;
 import uk.gov.companieshouse.logging.Logger;
 
+/**
+ * Testing/diagnostic endpoints for activation-date -based payment templates. Only instantiated when
+ * env var {@code FEATURE_TESTING_FEES=true} (default is false)
+ */
 @RestController
 @ConditionalOnProperty(prefix = "feature", name = "testing-fees", havingValue = "true")
 @ResponseStatus(HttpStatus.OK)
@@ -46,11 +50,17 @@ public class PaymentFeatureTestingFeesController {
     }
 
     /**
-     * Returns a responseEntity which contains a list of payment templates belonging to an optional
-     * fee type at an optional active_from date/time, or all templates if fee type and active_from
-     * are omitted.
+     * Returns a responseEntity which contains a list of {@link PaymentTemplate} belonging to an
+     * optional
+     * fee id, and also that is active at an optional local date/time, or all
+     * {@link PaymentTemplate} otherwise.
+     * @param fee (optional unless {@code activeAt} is not omitted) the fee id associated with a
+     *            form template
+     * @param activeAt (optional) a {@link LocalDateTime} at which that the resultant
+     * {@link PaymentTemplate} is active
      *
-     * @return responseEntity
+     * @return responseEntity containing list of {@link PaymentTemplate}. Will consist of a
+     * single value if {@code fee} and {@code activeAt} are specified.
      */
     @GetMapping(produces = {"application/json"})
     public ResponseEntity<List<PaymentTemplate>> getPaymentTemplates(
@@ -87,6 +97,9 @@ public class PaymentFeatureTestingFeesController {
         }
     }
 
+    /**
+     * DTO class used as request body by {@link #createPaymentTemplate}
+     */
     static class TestPaymentTemplate {
         final String fee;
         final LocalDateTime activeFrom;
@@ -124,6 +137,19 @@ public class PaymentFeatureTestingFeesController {
         }
     }
 
+    /**
+     * Create and store a bare-bones payment template for test purposes.
+     * Details required in request body (a {@link TestPaymentTemplate} DTO):
+     * <ul>
+     *     <li>Fee ID</li>
+     *     <li>ActiveFrom local date/time</li>
+     *     <li>Amount</li>
+     * </ul>
+     *
+     * @param templateDetails the DTO containing details to be stored
+     *
+     * @return the {@link PaymentTemplate} as stored
+     */
     @PostMapping(value = "/test-fee", consumes = {"application/json"},
         produces = {"application/json"})
     public ResponseEntity<PaymentTemplate> createPaymentTemplate(

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentFeatureTestingFeesController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentFeatureTestingFeesController.java
@@ -33,13 +33,13 @@ import uk.gov.companieshouse.logging.Logger;
 @ConditionalOnProperty(prefix = "feature", name = "testing-fees", havingValue = "true")
 @ResponseStatus(HttpStatus.OK)
 @RequestMapping("/efs-submission-api/payment-templates")
-public class PaymentControllerSpike {
+public class PaymentFeatureTestingFeesController {
     private static final LocalDateTime CHARGE_TIMESTAMP = LocalDateTime.parse("2019-01-08T00:00:00");
     private final Logger logger;
     private final PaymentTemplateService paymentTemplateService;
 
     @Autowired
-    public PaymentControllerSpike(final PaymentTemplateService paymentTemplateService,
+    public PaymentFeatureTestingFeesController(final PaymentTemplateService paymentTemplateService,
             Logger logger) {
         this.paymentTemplateService = paymentTemplateService;
         this.logger = logger;

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentFeatureTestingFeesController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentFeatureTestingFeesController.java
@@ -100,13 +100,13 @@ public class PaymentFeatureTestingFeesController {
     /**
      * DTO class used as request body by {@link #createPaymentTemplate}
      */
-    static class TestPaymentTemplate {
+    public static class TestingFeesPaymentTemplate {
         final String fee;
         final LocalDateTime activeFrom;
         final String amount;
 
         @JsonCreator
-        public TestPaymentTemplate(@JsonProperty("fee") final String fee,
+        public TestingFeesPaymentTemplate(@JsonProperty("fee") final String fee,
             @JsonProperty("active_from") final LocalDateTime activeFrom,
             @JsonProperty("amount") final String amount) {
             this.fee = fee;
@@ -129,7 +129,7 @@ public class PaymentFeatureTestingFeesController {
 
         @Override
         public String toString() {
-            return new StringJoiner(", ", TestPaymentTemplate.class.getSimpleName() + "[", "]")
+            return new StringJoiner(", ", TestingFeesPaymentTemplate.class.getSimpleName() + "[", "]")
                 .add("fee='" + fee + "'")
                 .add("activeFrom=" + activeFrom)
                 .add("amount='" + amount + "'")
@@ -139,7 +139,7 @@ public class PaymentFeatureTestingFeesController {
 
     /**
      * Create and store a bare-bones payment template for test purposes.
-     * Details required in request body (a {@link TestPaymentTemplate} DTO):
+     * Details required in request body (a {@link TestingFeesPaymentTemplate} DTO):
      * <ul>
      *     <li>Fee ID</li>
      *     <li>ActiveFrom local date/time</li>
@@ -153,7 +153,7 @@ public class PaymentFeatureTestingFeesController {
     @PostMapping(value = "/test-fee", consumes = {"application/json"},
         produces = {"application/json"})
     public ResponseEntity<PaymentTemplate> createPaymentTemplate(
-        @RequestBody final TestPaymentTemplate templateDetails) {
+        @RequestBody final TestingFeesPaymentTemplate templateDetails) {
 
         final PaymentTemplate.Item item = PaymentTemplate.Item.newBuilder()
             .withAmount(templateDetails.getAmount())

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.persistence.EmbeddedId;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.annotation.Id;
@@ -248,6 +249,10 @@ public final class PaymentTemplate {
          */
         public static final class Builder {
             private String amount;
+            @JsonProperty("start_timestamp_utc")
+            private String startTimestampUtc;
+            @JsonProperty("end_timestamp_utc")
+            private String endTimestampUtc;
             @JsonProperty("available_payment_methods")
             private List<String> availablePaymentMethods;
             @JsonProperty("class_of_payment")
@@ -270,6 +275,28 @@ public final class PaymentTemplate {
              */
             public Builder withAmount(final String val) {
                 amount = val;
+                return this;
+            }
+
+            /**
+             * set the startTimestampUtc on the {@code PaymentTemplate}
+             *
+             * @param val the amount
+             * @return builder with the amount set to specified value
+             */
+            public Builder withStartTimestampUtc(final String val){
+                startTimestampUtc = val;
+                return this;
+            }
+
+            /**
+             * set the endTimestampUtc on the {@code PaymentTemplate}
+             *
+             * @param val the amount
+             * @return builder with the amount set to specified value
+             */
+            public Builder withEndTimestampUtc(final String val){
+                endTimestampUtc = val;
                 return this;
             }
 
@@ -443,9 +470,8 @@ public final class PaymentTemplate {
         }
     }
 
-    @Id
-    private String id;
-
+    @EmbeddedId
+    private PaymentTemplateId id;
     @Field
     private String description;
     @Field
@@ -465,11 +491,11 @@ public final class PaymentTemplate {
     @Transient // not an entity field; for use by PaymentController.getPaymentDetails() response
     private String companyNumber;
 
-    public String getId() {
+    public PaymentTemplateId getId() {
         return id;
     }
 
-    public void setId(final String id) {
+    public void setId(final PaymentTemplateId id) {
         this.id = id;
     }
 
@@ -577,7 +603,7 @@ public final class PaymentTemplate {
      * {@code PaymentTemplate} static builder class
      */
     public static final class Builder {
-        private String id;
+        private PaymentTemplateId id;
         private String description;
         private String etag;
         @JsonProperty("items")
@@ -599,7 +625,7 @@ public final class PaymentTemplate {
          * @param val the id
          * @return builder with the id set to specified value
          */
-        public Builder withId(final String val) {
+        public Builder withId(final PaymentTemplateId val) {
             id = val;
             return this;
         }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 import javax.persistence.EmbeddedId;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -232,6 +231,7 @@ public final class PaymentTemplate {
         @Override
         public String toString() {
             return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                    //TODO - add id
                 .append("amount", amount).append("availablePaymentMethods", availablePaymentMethods)
                 .append("classOfPayment", classOfPayment).append("description", description)
                 .append("descriptionId", descriptionId).append("kind", kind)
@@ -249,10 +249,6 @@ public final class PaymentTemplate {
          */
         public static final class Builder {
             private String amount;
-            @JsonProperty("start_timestamp_utc")
-            private String startTimestampUtc;
-            @JsonProperty("end_timestamp_utc")
-            private String endTimestampUtc;
             @JsonProperty("available_payment_methods")
             private List<String> availablePaymentMethods;
             @JsonProperty("class_of_payment")
@@ -275,28 +271,6 @@ public final class PaymentTemplate {
              */
             public Builder withAmount(final String val) {
                 amount = val;
-                return this;
-            }
-
-            /**
-             * set the startTimestampUtc on the {@code PaymentTemplate}
-             *
-             * @param val the amount
-             * @return builder with the amount set to specified value
-             */
-            public Builder withStartTimestampUtc(final String val){
-                startTimestampUtc = val;
-                return this;
-            }
-
-            /**
-             * set the endTimestampUtc on the {@code PaymentTemplate}
-             *
-             * @param val the amount
-             * @return builder with the amount set to specified value
-             */
-            public Builder withEndTimestampUtc(final String val){
-                endTimestampUtc = val;
                 return this;
             }
 
@@ -573,22 +547,16 @@ public final class PaymentTemplate {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof PaymentTemplate)) {
             return false;
         }
         final PaymentTemplate that = (PaymentTemplate) o;
-        return Objects.equals(getId(), that.getId()) && Objects.equals(getDescription(), that.getDescription())
-            && Objects.equals(getEtag(), that.getEtag()) && Objects.equals(getItems(), that.getItems()) && Objects
-            .equals(getKind(), that.getKind()) && Objects.equals(getLinks(), that.getLinks()) && Objects
-            .equals(getPaymentReference(), that.getPaymentReference()) && getStatus() == that.getStatus() && Objects
-            .equals(getCompanyNumber(), that.getCompanyNumber());
+        return com.google.common.base.Objects.equal(getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects
-            .hash(getId(), getDescription(), getEtag(), getItems(), getKind(), getLinks(), getPaymentReference(),
-                getStatus(), getCompanyNumber());
+        return com.google.common.base.Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplate.java
@@ -231,7 +231,6 @@ public final class PaymentTemplate {
         @Override
         public String toString() {
             return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-                    //TODO - add id
                 .append("amount", amount).append("availablePaymentMethods", availablePaymentMethods)
                 .append("classOfPayment", classOfPayment).append("description", description)
                 .append("descriptionId", descriptionId).append("kind", kind)

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.efs.api.payment.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import java.io.Serializable;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import javax.persistence.Embeddable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -17,12 +17,12 @@ public final class PaymentTemplateId implements Serializable {
     private String fee;
     @Field("start_timestamp")
     @JsonProperty("start_timestamp")
-    private Instant startTimestamp;
+    private LocalDateTime startTimestamp;
 
     public PaymentTemplateId() {
     }
 
-    public PaymentTemplateId(final String fee, final Instant startTimestamp) {
+    public PaymentTemplateId(final String fee, final LocalDateTime startTimestamp) {
         this.fee = fee;
         this.startTimestamp = startTimestamp;
     }
@@ -31,7 +31,7 @@ public final class PaymentTemplateId implements Serializable {
         return fee;
     }
 
-    public Instant getStartTimestamp() {
+    public LocalDateTime getStartTimestamp() {
         return startTimestamp;
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
@@ -1,0 +1,53 @@
+package uk.gov.companieshouse.efs.api.payment.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+import javax.persistence.Embeddable;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Embeddable
+public class PaymentTemplateId implements Serializable {
+
+    private static final long serialVersionUID = -3666317728117130710L;
+
+    private String fee;
+    @Field("start_timestamp_utc")
+    @JsonProperty("start_timestamp_utc")
+    private Instant startTimestampUtc;
+
+    public PaymentTemplateId() {
+    }
+
+    public PaymentTemplateId(final String fee, final Instant startTimestampUtc) {
+        this.fee = fee;
+        this.startTimestampUtc = startTimestampUtc;
+    }
+
+    public String getFee() {
+        return fee;
+    }
+
+    public Instant getStartTimestampUtc() {
+        return startTimestampUtc;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PaymentTemplateId)) {
+            return false;
+        }
+        final PaymentTemplateId that = (PaymentTemplateId) o;
+        return Objects.equals(getFee(), that.getFee()) && Objects.equals(getStartTimestampUtc(),
+                that.getStartTimestampUtc());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getFee(), getStartTimestampUtc());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
@@ -15,24 +15,24 @@ public final class PaymentTemplateId implements Serializable {
     private static final long serialVersionUID = -3666317728117130710L;
 
     private String fee;
-    @Field("start_timestamp")
-    @JsonProperty("start_timestamp")
-    private LocalDateTime startTimestamp;
+    @Field("active_from")
+    @JsonProperty("active_from")
+    private LocalDateTime activeFrom;
 
     public PaymentTemplateId() {
     }
 
-    public PaymentTemplateId(final String fee, final LocalDateTime startTimestamp) {
+    public PaymentTemplateId(final String fee, final LocalDateTime activeFrom) {
         this.fee = fee;
-        this.startTimestamp = startTimestamp;
+        this.activeFrom = activeFrom;
     }
 
     public String getFee() {
         return fee;
     }
 
-    public LocalDateTime getStartTimestamp() {
-        return startTimestamp;
+    public LocalDateTime getActiveFrom() {
+        return activeFrom;
     }
 
     @Override
@@ -44,19 +44,19 @@ public final class PaymentTemplateId implements Serializable {
             return false;
         }
         final PaymentTemplateId that = (PaymentTemplateId) o;
-        return Objects.equal(getFee(), that.getFee()) && Objects.equal(getStartTimestamp(),
-                that.getStartTimestamp());
+        return Objects.equal(getFee(), that.getFee()) && Objects.equal(getActiveFrom(),
+            that.getActiveFrom());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getFee(), getStartTimestamp());
+        return Objects.hashCode(getFee(), getActiveFrom());
     }
 
     @Override
     public java.lang.String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("fee", fee)
-                .append("startTimestamp", startTimestamp)
+            .append("activeFrom", getActiveFrom())
                 .toString();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
@@ -9,6 +9,15 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+/**
+ * Embedded composite key entity that identifies a unique {@link PaymentTemplate}:
+ * <ul>
+ *     <li>fee: the Fee ID</li>
+ *     <li>activeFrom: the {@link LocalDateTime} when the parent {@link PaymentTemplate} becomes
+ *     active. <b>Note: </b>This will be converted and stored as a UTC value on the database
+ *     side.</li>
+ * </ul>
+ */
 @Embeddable
 public final class PaymentTemplateId implements Serializable {
 
@@ -19,9 +28,17 @@ public final class PaymentTemplateId implements Serializable {
     @JsonProperty("active_from")
     private LocalDateTime activeFrom;
 
+    /**
+     * No-arg constructor.
+     */
     public PaymentTemplateId() {
     }
 
+    /**
+     * All-arg constructor.
+     * @param fee the fee id code
+     * @param activeFrom the local date/time when activeness begins
+     */
     public PaymentTemplateId(final String fee, final LocalDateTime activeFrom) {
         this.fee = fee;
         this.activeFrom = activeFrom;

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateId.java
@@ -1,36 +1,38 @@
 package uk.gov.companieshouse.efs.api.payment.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.Objects;
 import javax.persistence.Embeddable;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Embeddable
-public class PaymentTemplateId implements Serializable {
+public final class PaymentTemplateId implements Serializable {
 
     private static final long serialVersionUID = -3666317728117130710L;
 
     private String fee;
-    @Field("start_timestamp_utc")
-    @JsonProperty("start_timestamp_utc")
-    private Instant startTimestampUtc;
+    @Field("start_timestamp")
+    @JsonProperty("start_timestamp")
+    private Instant startTimestamp;
 
     public PaymentTemplateId() {
     }
 
-    public PaymentTemplateId(final String fee, final Instant startTimestampUtc) {
+    public PaymentTemplateId(final String fee, final Instant startTimestamp) {
         this.fee = fee;
-        this.startTimestampUtc = startTimestampUtc;
+        this.startTimestamp = startTimestamp;
     }
 
     public String getFee() {
         return fee;
     }
 
-    public Instant getStartTimestampUtc() {
-        return startTimestampUtc;
+    public Instant getStartTimestamp() {
+        return startTimestamp;
     }
 
     @Override
@@ -42,12 +44,19 @@ public class PaymentTemplateId implements Serializable {
             return false;
         }
         final PaymentTemplateId that = (PaymentTemplateId) o;
-        return Objects.equals(getFee(), that.getFee()) && Objects.equals(getStartTimestampUtc(),
-                that.getStartTimestampUtc());
+        return Objects.equal(getFee(), that.getFee()) && Objects.equal(getStartTimestamp(),
+                that.getStartTimestamp());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getFee(), getStartTimestampUtc());
+        return Objects.hashCode(getFee(), getStartTimestamp());
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("fee", fee)
+                .append("startTimestamp", startTimestamp)
+                .toString();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
@@ -9,7 +9,8 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
  * Store and retrieve payment template information
  */
 public interface PaymentTemplateRepository extends MongoRepository<PaymentTemplate, String> {
-    Optional<PaymentTemplate> findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(
+    @SuppressWarnings("java:S100")
+    Optional<PaymentTemplate> findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
         String fee, LocalDateTime activeAt);
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.efs.api.payment.repository;
 
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
 
@@ -7,5 +8,6 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
  * Store and retrieve payment template information
  */
 public interface PaymentTemplateRepository extends MongoRepository<PaymentTemplate, String> {
+    Optional<PaymentTemplate> findFirstById_FeeOrderById_StartTimestampUtcDesc(String fee);
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.efs.api.payment.repository;
 
+import java.time.Instant;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
@@ -8,6 +9,7 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
  * Store and retrieve payment template information
  */
 public interface PaymentTemplateRepository extends MongoRepository<PaymentTemplate, String> {
-    Optional<PaymentTemplate> findFirstById_FeeOrderById_StartTimestampUtcDesc(String fee);
+    Optional<PaymentTemplate> findFirstById_FeeAndId_StartTimestampUtcLessThanEqualOrderById_StartTimestampUtcDesc(
+            String fee, Instant startTimestampUtc);
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.payment.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
@@ -12,5 +13,9 @@ public interface PaymentTemplateRepository extends MongoRepository<PaymentTempla
     @SuppressWarnings("java:S100")
     Optional<PaymentTemplate> findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
         String fee, LocalDateTime activeAt);
+
+    @SuppressWarnings("java:S100")
+    List<PaymentTemplate> findById_FeeOrderById_ActiveFromDesc(String fee);
+
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
@@ -9,7 +9,7 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
  * Store and retrieve payment template information
  */
 public interface PaymentTemplateRepository extends MongoRepository<PaymentTemplate, String> {
-    Optional<PaymentTemplate> findFirstById_FeeAndId_StartTimestampUtcLessThanEqualOrderById_StartTimestampUtcDesc(
+    Optional<PaymentTemplate> findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(
             String fee, Instant startTimestampUtc);
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
@@ -10,12 +10,25 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
  * Store and retrieve payment template information
  */
 public interface PaymentTemplateRepository extends MongoRepository<PaymentTemplate, String> {
+    /**
+     * Find the single {@link PaymentTemplate} having {@code fee} equal to the specified {@code fee}
+     * and {@code activeFrom} on or before the specified {@code activeAt} date/time.
+     *
+     * @param fee      the fee ID to query
+     * @param activeAt the local date/time to query
+     * @return the {@link PaymentTemplate} found, if any, wrapped in an {@link Optional}.
+     */
     @SuppressWarnings("java:S100")
     Optional<PaymentTemplate> findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
         String fee, LocalDateTime activeAt);
 
+    /**
+     * Find list of {@link PaymentTemplate}s having {@code fee} equal to the specified {@code fee}.
+     *
+     * @param fee the fee ID to query
+     * @return the collection of {@link PaymentTemplate} found, if any, wrapped in a {@link List}.
+     */
     @SuppressWarnings("java:S100")
     List<PaymentTemplate> findById_FeeOrderById_ActiveFromDesc(String fee);
-
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/repository/PaymentTemplateRepository.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.efs.api.payment.repository;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
@@ -10,6 +10,6 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
  */
 public interface PaymentTemplateRepository extends MongoRepository<PaymentTemplate, String> {
     Optional<PaymentTemplate> findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(
-            String fee, Instant startTimestampUtc);
+        String fee, LocalDateTime activeAt);
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.efs.api.payment.service;
 
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
 
@@ -17,7 +18,26 @@ public interface PaymentTemplateService {
      * @param activeAt the local date/time for which the template must be active
      * @return the payment template
      */
-    default Optional<PaymentTemplate> getTemplate(String fee, LocalDateTime activeAt) {
+    default Optional<PaymentTemplate> getPaymentTemplate(String fee, LocalDateTime activeAt) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
+     * Retrieve the all templates for the specified id
+     *
+     * @param fee the payment template id of the template(s)
+     * @return the payment template
+     */
+    default List<PaymentTemplate> getPaymentTemplates(String fee) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
+     * Retrieve the all templates
+     *
+     * @return the payment template list
+     */
+    default List<PaymentTemplate> getPaymentTemplates() {
         throw new UnsupportedOperationException("not implemented");
     }
 
@@ -25,8 +45,9 @@ public interface PaymentTemplateService {
      * Store the payment template
      *
      * @param template the payment template to be stored
+     * @return
      */
-    default void putTemplate(PaymentTemplate template) {
+    default PaymentTemplate postTemplate(PaymentTemplate template) {
         throw new UnsupportedOperationException("not implemented");
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.payment.service;
 
 
+import java.time.Instant;
 import java.util.Optional;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
 
@@ -12,10 +13,10 @@ public interface PaymentTemplateService {
     /**
      * Retrieve the template for the specified id
      *
-     * @param id the payment template id
+     * @param fee the payment template id
      * @return the payment template
      */
-    default Optional<PaymentTemplate> getTemplate(String id) {
+    default Optional<PaymentTemplate> getTemplate(String fee, Instant chargedAt) {
         throw new UnsupportedOperationException("not implemented");
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.efs.api.payment.service;
 
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
 
@@ -11,12 +11,13 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
 public interface PaymentTemplateService {
 
     /**
-     * Retrieve the template for the specified id
+     * Retrieve the template for the specified id active at the specified date/time
      *
-     * @param fee the payment template id
+     * @param fee the payment template id of the template
+     * @param activeAt the local date/time for which the template must be active
      * @return the payment template
      */
-    default Optional<PaymentTemplate> getTemplate(String fee, Instant chargedAt) {
+    default Optional<PaymentTemplate> getTemplate(String fee, LocalDateTime activeAt) {
         throw new UnsupportedOperationException("not implemented");
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateService.java
@@ -12,40 +12,41 @@ import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
 public interface PaymentTemplateService {
 
     /**
-     * Retrieve the template for the specified id active at the specified date/time
+     * Find the single {@link PaymentTemplate} having {@code fee} equal to the specified {@code fee}
+     * and {@code activeFrom} on or before the specified {@code activeAt} date/time.
      *
-     * @param fee the payment template id of the template
-     * @param activeAt the local date/time for which the template must be active
-     * @return the payment template
+     * @param fee      the fee ID to query
+     * @param activeAt the local date/time to query
+     * @return the {@link PaymentTemplate} found, if any, wrapped in an {@link Optional}.
      */
     default Optional<PaymentTemplate> getPaymentTemplate(String fee, LocalDateTime activeAt) {
         throw new UnsupportedOperationException("not implemented");
     }
 
     /**
-     * Retrieve the all templates for the specified id
+     * Find the {@link PaymentTemplate}s having {@code fee} equal to the specified {@code fee}.
      *
-     * @param fee the payment template id of the template(s)
-     * @return the payment template
+     * @param fee the fee ID to query
+     * @return the collection of {@link PaymentTemplate} found, if any, wrapped in a {@link List}.
      */
     default List<PaymentTemplate> getPaymentTemplates(String fee) {
         throw new UnsupportedOperationException("not implemented");
     }
 
     /**
-     * Retrieve the all templates
+     * Find all {@link PaymentTemplate}s.
      *
-     * @return the payment template list
+     * @return the collection of {@link PaymentTemplate} found, if any, wrapped in a {@link List}.
      */
     default List<PaymentTemplate> getPaymentTemplates() {
         throw new UnsupportedOperationException("not implemented");
     }
 
     /**
-     * Store the payment template
+     * Store the {@link PaymentTemplate}.
      *
-     * @param template the payment template to be stored
-     * @return
+     * @param template the {@link PaymentTemplate} to be stored
+     * @return the {@link PaymentTemplate} stored
      */
     default PaymentTemplate postTemplate(PaymentTemplate template) {
         throw new UnsupportedOperationException("not implemented");

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.efs.api.payment.service;
 
+import java.time.Instant;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -14,7 +15,7 @@ import uk.gov.companieshouse.efs.api.payment.repository.PaymentTemplateRepositor
 @Service
 @Import(Config.class)
 public class PaymentTemplateServiceImpl implements PaymentTemplateService {
-    private PaymentTemplateRepository repository;
+    private final PaymentTemplateRepository repository;
 
     /**
      * PaymentTemplateService constructor
@@ -26,13 +27,17 @@ public class PaymentTemplateServiceImpl implements PaymentTemplateService {
         this.repository = repository;
     }
 
+    //TODO
     @Override
-    public Optional<PaymentTemplate> getTemplate(final String id) {
-        return repository.findById(id);
+    public Optional<PaymentTemplate> getTemplate(final String fee, final Instant chargedAt) {
+        return repository.findFirstById_FeeOrderById_StartTimestampUtcDesc(fee);
+
     }
+
 
     @Override
     public void putTemplate(final PaymentTemplate template) {
         repository.save(template);
     }
+
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
@@ -29,7 +29,7 @@ public class PaymentTemplateServiceImpl implements PaymentTemplateService {
 
     @Override
     public Optional<PaymentTemplate> getTemplate(final String fee, final LocalDateTime activeAt) {
-        return repository.findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(fee,
+        return repository.findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(fee,
             activeAt);
 
     }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
@@ -27,13 +27,11 @@ public class PaymentTemplateServiceImpl implements PaymentTemplateService {
         this.repository = repository;
     }
 
-    //TODO
     @Override
     public Optional<PaymentTemplate> getTemplate(final String fee, final Instant chargedAt) {
-        return repository.findFirstById_FeeAndId_StartTimestampUtcLessThanEqualOrderById_StartTimestampUtcDesc(fee, chargedAt);
+        return repository.findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(fee, chargedAt);
 
     }
-
 
     @Override
     public void putTemplate(final PaymentTemplate template) {

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.efs.api.payment.service;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -28,8 +28,9 @@ public class PaymentTemplateServiceImpl implements PaymentTemplateService {
     }
 
     @Override
-    public Optional<PaymentTemplate> getTemplate(final String fee, final Instant chargedAt) {
-        return repository.findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(fee, chargedAt);
+    public Optional<PaymentTemplate> getTemplate(final String fee, final LocalDateTime activeAt) {
+        return repository.findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(fee,
+            activeAt);
 
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.efs.api.payment.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -17,26 +18,31 @@ import uk.gov.companieshouse.efs.api.payment.repository.PaymentTemplateRepositor
 public class PaymentTemplateServiceImpl implements PaymentTemplateService {
     private final PaymentTemplateRepository repository;
 
-    /**
-     * PaymentTemplateService constructor
-     *
-     * @param repository the {@link PaymentTemplateRepository}
-     */
     @Autowired
     public PaymentTemplateServiceImpl(final PaymentTemplateRepository repository) {
         this.repository = repository;
     }
 
     @Override
-    public Optional<PaymentTemplate> getTemplate(final String fee, final LocalDateTime activeAt) {
-        return repository.findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(fee,
-            activeAt);
+    public Optional<PaymentTemplate> getPaymentTemplate(final String fee, final LocalDateTime activeAt) {
+        return repository.findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
+            fee, activeAt);
 
     }
 
     @Override
-    public void putTemplate(final PaymentTemplate template) {
-        repository.save(template);
+    public List<PaymentTemplate> getPaymentTemplates(String fee) {
+        return repository.findById_FeeOrderById_ActiveFromDesc(fee);
+    }
+
+    @Override
+    public List<PaymentTemplate> getPaymentTemplates() {
+        return repository.findAll();
+    }
+
+    @Override
+    public PaymentTemplate postTemplate(final PaymentTemplate template) {
+        return repository.save(template);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImpl.java
@@ -30,7 +30,7 @@ public class PaymentTemplateServiceImpl implements PaymentTemplateService {
     //TODO
     @Override
     public Optional<PaymentTemplate> getTemplate(final String fee, final Instant chargedAt) {
-        return repository.findFirstById_FeeOrderById_StartTimestampUtcDesc(fee);
+        return repository.findFirstById_FeeAndId_StartTimestampUtcLessThanEqualOrderById_StartTimestampUtcDesc(fee, chargedAt);
 
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
@@ -376,9 +376,9 @@ public class SubmissionServiceImpl implements SubmissionService {
             if (StringUtils.isNotBlank(paymentCharge)) {
                 LOGGER.debug(String.format("Payment charge for form [%s] is [%s]", formType, paymentCharge));
 
-                final Optional<PaymentTemplate> template = paymentTemplateService.getTemplate(paymentCharge);
+                //FIXME final Optional<PaymentTemplate> template = paymentTemplateService.getTemplate(paymentCharge);
 
-                result = template.map(t -> t.getItems().get(0).getAmount()).orElse(null);
+                //FIXME result = template.map(t -> t.getItems().get(0).getAmount()).orElse(null);
             }
         }
         if (result == null) {

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
@@ -376,9 +376,9 @@ public class SubmissionServiceImpl implements SubmissionService {
             if (StringUtils.isNotBlank(paymentCharge)) {
                 LOGGER.debug(String.format("Payment charge for form [%s] is [%s]", formType, paymentCharge));
 
-                //FIXME final Optional<PaymentTemplate> template = paymentTemplateService.getTemplate(paymentCharge);
+                final Optional<PaymentTemplate> template = paymentTemplateService.getTemplate(paymentCharge, null);
 
-                //FIXME result = template.map(t -> t.getItems().get(0).getAmount()).orElse(null);
+                result = template.map(t -> t.getItems().get(0).getAmount()).orElse(null);
             }
         }
         if (result == null) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -82,3 +82,5 @@ env.name=${ENV_NAME}
 
 scotland.company.prefixes=${SCOTLAND_COMPANY_PREFIXES}
 northernIreland.company.prefixes=${NORTHERN_IRELAND_COMPANY_PREFIXES}
+
+feature.testing-fees=${FEATURE_TESTING_FEES}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,4 +83,4 @@ env.name=${ENV_NAME}
 scotland.company.prefixes=${SCOTLAND_COMPANY_PREFIXES}
 northernIreland.company.prefixes=${NORTHERN_IRELAND_COMPANY_PREFIXES}
 
-feature.testing-fees=${FEATURE_TESTING_FEES}
+feature.testing-fees=${FEATURE_TESTING_FEES:false}

--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -17,7 +17,7 @@
         "class_of_payment": [
           "data-maintenance"
         ],
-        "description": "Upload a document to Companies House: SLPCS01",
+        "description": "Upload a document to Companies House: SLPCS01 at midnight",
         "description_identifier": "EFS_SLPCS01",
         "kind": "cost#cost",
         "product_type": "efs-slpcs01"
@@ -32,11 +32,37 @@
         "$date":"2019-01-08T00:00:01.000Z"
       }
     },
-    "description": "Upload form SLPCS01",
+    "description": "Upload form SLPCS01 after midnight",
     "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
     "items": [
       {
         "amount": "57",
+        "available_payment_methods": [
+          "credit-card"
+        ],
+        "class_of_payment": [
+          "data-maintenance"
+        ],
+        "description": "Upload a document to Companies House: SLPCS01",
+        "description_identifier": "EFS_SLPCS01",
+        "kind": "cost#cost",
+        "product_type": "efs-slpcs01"
+      }
+    ],
+    "kind": "EFS"
+  },
+  {
+    "_id": {
+      "fee": "SLPCS01",
+      "start_timestamp_utc": {
+        "$date":"2019-01-07T23:59:59.000Z"
+      }
+    },
+    "description": "Upload form SLPCS01 before midnight",
+    "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
+    "items": [
+      {
+        "amount": "7",
         "available_payment_methods": [
           "credit-card"
         ],

--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -2,7 +2,7 @@
   {
     "_id": {
       "fee": "SLPCS01",
-      "start_timestamp_utc": {
+      "start_timestamp": {
         "$date":"2019-01-08T00:00:00.000Z"
       }
     },
@@ -28,7 +28,7 @@
   {
     "_id": {
       "fee": "SLPCS01",
-      "start_timestamp_utc": {
+      "start_timestamp": {
         "$date":"2019-01-08T00:00:01.000Z"
       }
     },
@@ -54,7 +54,7 @@
   {
     "_id": {
       "fee": "SLPCS01",
-      "start_timestamp_utc": {
+      "start_timestamp": {
         "$date":"2019-01-07T23:59:59.000Z"
       }
     },
@@ -80,7 +80,7 @@
   {
     "_id": {
       "fee": "SQPCS01",
-      "start_timestamp_utc": {
+      "start_timestamp": {
       "$date":"2019-01-08T00:00:00.000Z"
     }
     },
@@ -106,7 +106,7 @@
   {
     "_id": {
       "fee": "SH19",
-      "start_timestamp_utc": {
+      "start_timestamp": {
         "$date":"2019-01-08T00:00:00.000Z"
       }
     },
@@ -132,7 +132,7 @@
   {
     "_id": {
       "fee": "SH19_SAMEDAY",
-      "start_timestamp_utc": {
+      "start_timestamp": {
         "$date":"2019-01-08T00:00:00.000Z"
       }
     },

--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -2,11 +2,11 @@
   {
     "_id": {
       "fee": "SLPCS01",
-      "start_timestamp": {
-        "$date":"2019-01-08T00:00:00.000Z"
+      "active_from": {
+        "$date":"2020-10-29T00:00:00.000Z"
       }
     },
-    "description": "Upload form SLPCS01 with start timesstamp",
+    "description": "Upload form SLPCS01: 2020-10-29",
     "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
     "items": [
       {
@@ -17,7 +17,7 @@
         "class_of_payment": [
           "data-maintenance"
         ],
-        "description": "Upload a document to Companies House: SLPCS01 at midnight",
+        "description": "Upload a document to Companies House: SLPCS01",
         "description_identifier": "EFS_SLPCS01",
         "kind": "cost#cost",
         "product_type": "efs-slpcs01"
@@ -28,11 +28,11 @@
   {
     "_id": {
       "fee": "SLPCS01",
-      "start_timestamp": {
-        "$date":"2019-01-08T00:00:01.000Z"
+      "active_from": {
+        "$date":"2024-01-08T00:00:00.000Z"
       }
     },
-    "description": "Upload form SLPCS01 after midnight",
+    "description": "Upload form SLPCS01: 2024-01-08",
     "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
     "items": [
       {
@@ -53,38 +53,12 @@
   },
   {
     "_id": {
-      "fee": "SLPCS01",
-      "start_timestamp": {
-        "$date":"2019-01-07T23:59:59.000Z"
-      }
-    },
-    "description": "Upload form SLPCS01 before midnight",
-    "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
-    "items": [
-      {
-        "amount": "7",
-        "available_payment_methods": [
-          "credit-card"
-        ],
-        "class_of_payment": [
-          "data-maintenance"
-        ],
-        "description": "Upload a document to Companies House: SLPCS01",
-        "description_identifier": "EFS_SLPCS01",
-        "kind": "cost#cost",
-        "product_type": "efs-slpcs01"
-      }
-    ],
-    "kind": "EFS"
-  },
-  {
-    "_id": {
       "fee": "SQPCS01",
-      "start_timestamp": {
-      "$date":"2019-01-08T00:00:00.000Z"
+      "active_from": {
+      "$date":"2020-10-29T00:00:00.000Z"
     }
     },
-    "description": "Upload form SQPCS01",
+    "description": "Upload form SQPCS01: 2020-10-29",
     "etag": "a6232d3cc78ff7092c39e68bedea049fcfbccc8d",
     "items": [
       {
@@ -105,12 +79,38 @@
   },
   {
     "_id": {
+      "fee": "SQPCS01",
+      "active_from": {
+      "$date":"2024-01-08T00:00:00.000Z"
+    }
+    },
+    "description": "Upload form SQPCS01: 2024-01-08",
+    "etag": "a6232d3cc78ff7092c39e68bedea049fcfbccc8d",
+    "items": [
+      {
+        "amount": "57",
+        "available_payment_methods": [
+          "credit-card"
+        ],
+        "class_of_payment": [
+          "data-maintenance"
+        ],
+        "description": "Upload a document to Companies House: SQPCS01",
+        "description_identifier": "EFS_SQPCS01",
+        "kind": "cost#cost",
+        "product_type": "efs-sqpcs01"
+      }
+    ],
+    "kind": "EFS"
+  },
+  {
+    "_id": {
       "fee": "SH19",
-      "start_timestamp": {
-        "$date":"2019-01-08T00:00:00.000Z"
+      "active_from": {
+        "$date":"2021-07-19T23:00:00.000Z"
       }
     },
-    "description": "Upload form SH19",
+    "description": "Upload form SH19: 2021-07-20",
     "etag": "2F9C0BC7B841A686BCCDA23C85AE54A3354B7B0F",
     "items": [
       {
@@ -131,16 +131,68 @@
   },
   {
     "_id": {
-      "fee": "SH19_SAMEDAY",
-      "start_timestamp": {
-        "$date":"2019-01-08T00:00:00.000Z"
+      "fee": "SH19",
+      "active_from": {
+        "$date":"2024-01-08T00:00:00.000Z"
       }
     },
-    "description": "Upload form SH19",
+    "description": "Upload form SH19: 2024-01-08",
+    "etag": "2F9C0BC7B841A686BCCDA23C85AE54A3354B7B0F",
+    "items": [
+      {
+        "amount": "29",
+        "available_payment_methods": [
+          "credit-card"
+        ],
+        "class_of_payment": [
+          "data-maintenance"
+        ],
+        "description": "Upload a document to Companies House: SH19",
+        "description_identifier": "EFS_SH19",
+        "kind": "cost#cost",
+        "product_type": "efs-sh19"
+      }
+    ],
+    "kind": "EFS"
+  },
+  {
+    "_id": {
+      "fee": "SH19_SAMEDAY",
+      "active_from": {
+        "$date":"2021-07-19T23:00:00.000Z"
+      }
+    },
+    "description": "Upload form SH19: 2021-07-20",
     "etag": "FB9F50ED470E23678519F3AE0E84F31587C43ED8",
     "items": [
       {
         "amount": "50",
+        "available_payment_methods": [
+          "credit-card"
+        ],
+        "class_of_payment": [
+          "data-maintenance"
+        ],
+        "description": "Upload a document to Companies House: SH19",
+        "description_identifier": "EFS_SH19_SAMEDAY",
+        "kind": "cost#cost",
+        "product_type": "efs-sh19-same-day"
+      }
+    ],
+    "kind": "EFS"
+  },
+  {
+    "_id": {
+      "fee": "SH19_SAMEDAY",
+      "active_from": {
+        "$date":"2024-01-08T00:00:00.000Z"
+      }
+    },
+    "description": "Upload form SH19: 2024-01-08",
+    "etag": "FB9F50ED470E23678519F3AE0E84F31587C43ED8",
+    "items": [
+      {
+        "amount": "121",
         "available_payment_methods": [
           "credit-card"
         ],

--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -1,7 +1,12 @@
 [
   {
-    "_id": "SLPCS01",
-    "description": "Upload form SLPCS01",
+    "_id": {
+      "fee": "SLPCS01",
+      "start_timestamp_utc": {
+        "$date":"2019-01-08T00:00:00.000Z"
+      }
+    },
+    "description": "Upload form SLPCS01 with start timesstamp",
     "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
     "items": [
       {
@@ -21,7 +26,38 @@
     "kind": "EFS"
   },
   {
-    "_id": "SQPCS01",
+    "_id": {
+      "fee": "SLPCS01",
+      "start_timestamp_utc": {
+        "$date":"2019-01-08T00:00:01.000Z"
+      }
+    },
+    "description": "Upload form SLPCS01",
+    "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
+    "items": [
+      {
+        "amount": "57",
+        "available_payment_methods": [
+          "credit-card"
+        ],
+        "class_of_payment": [
+          "data-maintenance"
+        ],
+        "description": "Upload a document to Companies House: SLPCS01",
+        "description_identifier": "EFS_SLPCS01",
+        "kind": "cost#cost",
+        "product_type": "efs-slpcs01"
+      }
+    ],
+    "kind": "EFS"
+  },
+  {
+    "_id": {
+      "fee": "SQPCS01",
+      "start_timestamp_utc": {
+      "$date":"2019-01-08T00:00:00.000Z"
+    }
+    },
     "description": "Upload form SQPCS01",
     "etag": "a6232d3cc78ff7092c39e68bedea049fcfbccc8d",
     "items": [
@@ -42,7 +78,12 @@
     "kind": "EFS"
   },
   {
-    "_id": "SH19",
+    "_id": {
+      "fee": "SH19",
+      "start_timestamp_utc": {
+        "$date":"2019-01-08T00:00:00.000Z"
+      }
+    },
     "description": "Upload form SH19",
     "etag": "2F9C0BC7B841A686BCCDA23C85AE54A3354B7B0F",
     "items": [
@@ -63,7 +104,12 @@
     "kind": "EFS"
   },
   {
-    "_id": "SH19_SAMEDAY",
+    "_id": {
+      "fee": "SH19_SAMEDAY",
+      "start_timestamp_utc": {
+        "$date":"2019-01-08T00:00:00.000Z"
+      }
+    },
     "description": "Upload form SH19",
     "etag": "FB9F50ED470E23678519F3AE0E84F31587C43ED8",
     "items": [

--- a/src/main/resources/payment_templates.json
+++ b/src/main/resources/payment_templates.json
@@ -21,26 +21,6 @@
   },
   {
     "_id": {
-      "fee": "SLPCS01",
-      "active_from": {"$date":"2024-01-08T00:00:00.000Z"}
-    },
-    "description": "Upload form SLPCS01: 2024-01-08",
-    "etag": "50ad23b174375c0e3343f9601b6128bb92ed079e",
-    "items": [
-      {
-        "amount": "57",
-        "available_payment_methods": ["credit-card"],
-        "class_of_payment": ["data-maintenance"],
-        "description": "Upload a document to Companies House: SLPCS01",
-        "description_identifier": "EFS_SLPCS01",
-        "kind": "cost#cost",
-        "product_type": "efs-slpcs01"
-      }
-    ],
-    "kind": "EFS"
-  },
-  {
-    "_id": {
       "fee": "SQPCS01",
       "active_from": {"$date":"2020-10-29T00:00:00.000Z"}
     },
@@ -49,26 +29,6 @@
     "items": [
       {
         "amount": "17",
-        "available_payment_methods": ["credit-card"],
-        "class_of_payment": ["data-maintenance"],
-        "description": "Upload a document to Companies House: SQPCS01",
-        "description_identifier": "EFS_SQPCS01",
-        "kind": "cost#cost",
-        "product_type": "efs-sqpcs01"
-      }
-    ],
-    "kind": "EFS"
-  },
-  {
-    "_id": {
-      "fee": "SQPCS01",
-      "active_from": {"$date":"2024-01-08T00:00:00.000Z"}
-    },
-    "description": "Upload form SQPCS01: 2024-01-08",
-    "etag": "a6232d3cc78ff7092c39e68bedea049fcfbccc8d",
-    "items": [
-      {
-        "amount": "57",
         "available_payment_methods": ["credit-card"],
         "class_of_payment": ["data-maintenance"],
         "description": "Upload a document to Companies House: SQPCS01",
@@ -101,26 +61,6 @@
   },
   {
     "_id": {
-      "fee": "SH19",
-      "active_from": {"$date":"2024-01-08T00:00:00.000Z"}
-    },
-    "description": "Upload form SH19: 2024-01-08",
-    "etag": "2F9C0BC7B841A686BCCDA23C85AE54A3354B7B0F",
-    "items": [
-      {
-        "amount": "29",
-        "available_payment_methods": ["credit-card"],
-        "class_of_payment": ["data-maintenance"],
-        "description": "Upload a document to Companies House: SH19",
-        "description_identifier": "EFS_SH19",
-        "kind": "cost#cost",
-        "product_type": "efs-sh19"
-      }
-    ],
-    "kind": "EFS"
-  },
-  {
-    "_id": {
       "fee": "SH19_SAMEDAY",
       "active_from": {"$date":"2021-07-19T23:00:00.000Z"}
     },
@@ -129,26 +69,6 @@
     "items": [
       {
         "amount": "50",
-        "available_payment_methods": ["credit-card"],
-        "class_of_payment": ["data-maintenance"],
-        "description": "Upload a document to Companies House: SH19",
-        "description_identifier": "EFS_SH19_SAMEDAY",
-        "kind": "cost#cost",
-        "product_type": "efs-sh19-same-day"
-      }
-    ],
-    "kind": "EFS"
-  },
-  {
-    "_id": {
-      "fee": "SH19_SAMEDAY",
-      "active_from": {"$date":"2024-01-08T00:00:00.000Z"}
-    },
-    "description": "Upload form SH19: 2024-01-08",
-    "etag": "FB9F50ED470E23678519F3AE0E84F31587C43ED8",
-    "items": [
-      {
-        "amount": "121",
         "available_payment_methods": ["credit-card"],
         "class_of_payment": ["data-maintenance"],
         "description": "Upload a document to Companies House: SH19",

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
@@ -121,7 +121,7 @@ class PaymentControllerTest {
 
         when(submissionService.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getPaymentTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
         when(request.getRequestURL()).thenReturn(
             new StringBuffer(PAYMENT_REQUEST_URL).append("/").append(SUB_ID).append("/"));
 
@@ -262,7 +262,7 @@ class PaymentControllerTest {
 
         when(submissionService.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(NOCHARGE)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(UNKNOWN, START_TIMESTAMP)).thenReturn(Optional.empty());
+        when(paymentTemplateService.getPaymentTemplate(UNKNOWN, START_TIMESTAMP)).thenReturn(Optional.empty());
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
@@ -281,7 +281,7 @@ class PaymentControllerTest {
 
         when(submissionService.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getPaymentTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:9999/efs-submission-api/submission{"));
 
         //when
@@ -302,7 +302,7 @@ class PaymentControllerTest {
 
         when(submissionService.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getPaymentTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
@@ -325,7 +325,7 @@ class PaymentControllerTest {
 
         when(submissionService.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getPaymentTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
@@ -11,7 +11,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,10 +60,13 @@ class PaymentControllerTest {
     public static final String CHARGED = "CHARGED";
     public static final String CHARGES = "CHARGES";
     public static final String UNKNOWN = "UNKNOWN";
-    private static final Instant START_TIMESTAMP_UTC = Instant.parse("2019-01-08T00:00:00.000Z");
+    private static final Instant START_TIMESTAMP_WINTER = Instant.parse("2019-01-08T00:00:00.000");
+    private static final Instant START_TIMESTAMP_SUMMER = Instant.parse("2019-07-08T00:00:00.000");
     public static final PaymentTemplateId CHARGED_TEMPLATE_ID = new PaymentTemplateId(CHARGED,
-            START_TIMESTAMP_UTC);
-
+            START_TIMESTAMP_WINTER);
+    private static final Clock CLOCK_FIXED_UTC = Clock.fixed(START_TIMESTAMP_WINTER, ZoneId.of("UTC"));
+    private static final ZonedDateTime TIME_BST = ZonedDateTime.ofInstant(START_TIMESTAMP_SUMMER, ZoneId.of("Europe/London"));
+    private static final Clock CLOCK_FIXED_BST = Clock.fixed(START_TIMESTAMP_SUMMER, ZoneId.of(""));
 
     @Mock
 
@@ -117,21 +124,19 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        //FIXME
-        //when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
-//        when(request.getRequestURL()).thenReturn(
-//            new StringBuffer(PAYMENT_REQUEST_URL).append("/").append(SUB_ID).append("/"));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
+        when(request.getRequestURL()).thenReturn(
+            new StringBuffer(PAYMENT_REQUEST_URL).append("/").append(SUB_ID).append("/"));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        //FIXME
-        //assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
 
-        //assertThat(paymentTemplate.getLinks().getSelf().toString(), is(PAYMENT_REQUEST_URL + "/" + SUB_ID));
-        //assertThat(paymentTemplate.getLinks().getResource(), is(PAYMENT_REQUEST_URL));
-        //assertThat(paymentTemplate.getCompanyNumber(), is(COMPANY_NUMBER));
+        assertThat(paymentTemplate.getLinks().getSelf().toString(), is(PAYMENT_REQUEST_URL + "/" + SUB_ID));
+        assertThat(paymentTemplate.getLinks().getResource(), is(PAYMENT_REQUEST_URL));
+        assertThat(paymentTemplate.getCompanyNumber(), is(COMPANY_NUMBER));
 
     }
 
@@ -260,13 +265,12 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(NOCHARGE)).thenReturn(formTemplate);
-        //FIXME when(paymentTemplateService.getTemplate(UNKNOWN)).thenReturn(Optional.empty());
+        when(paymentTemplateService.getTemplate(UNKNOWN, START_TIMESTAMP_WINTER)).thenReturn(Optional.empty());
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
-        //then
-        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
     @Test
@@ -280,15 +284,14 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        //FIXME when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
-        //FIXME when(request.getRequestURL())
-            //.thenReturn(new StringBuffer("http://localhost:9999/efs-submission-api/submission{"));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
+        when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:9999/efs-submission-api/submission{"));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+        assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
     }
 
     @Test
@@ -302,13 +305,13 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        //FIXME when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
 
     }
 
@@ -325,13 +328,13 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        //FIXME when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import uk.gov.companieshouse.efs.api.email.model.ExternalNotificationEmailModel;
 import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.efs.api.payment.PaymentClose;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
+import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateId;
 import uk.gov.companieshouse.efs.api.payment.service.PaymentTemplateService;
 import uk.gov.companieshouse.efs.api.submissions.mapper.SubmissionApiMapper;
 import uk.gov.companieshouse.efs.api.submissions.mapper.SubmissionMapper;
@@ -54,8 +56,13 @@ class PaymentControllerTest {
     public static final String CHARGED = "CHARGED";
     public static final String CHARGES = "CHARGES";
     public static final String UNKNOWN = "UNKNOWN";
+    private static final Instant START_TIMESTAMP_UTC = Instant.parse("2019-01-08T00:00:00.000Z");
+    public static final PaymentTemplateId CHARGED_TEMPLATE_ID = new PaymentTemplateId(CHARGED,
+            START_TIMESTAMP_UTC);
+
 
     @Mock
+
     private SessionListApi paymentSessions;
 
     private PaymentController paymentController;
@@ -106,23 +113,25 @@ class PaymentControllerTest {
             new Submission.Builder().withFormDetails(formDetails).withCompany(company).build());
         final FormTemplateApi formTemplate =
             new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
-        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
+        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED_TEMPLATE_ID).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
-        when(request.getRequestURL()).thenReturn(
-            new StringBuffer(PAYMENT_REQUEST_URL).append("/").append(SUB_ID).append("/"));
+        //FIXME
+        //when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
+//        when(request.getRequestURL()).thenReturn(
+//            new StringBuffer(PAYMENT_REQUEST_URL).append("/").append(SUB_ID).append("/"));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        //FIXME
+        //assertThat(response.getStatusCode(), is(HttpStatus.OK));
 
-        assertThat(paymentTemplate.getLinks().getSelf().toString(), is(PAYMENT_REQUEST_URL + "/" + SUB_ID));
-        assertThat(paymentTemplate.getLinks().getResource(), is(PAYMENT_REQUEST_URL));
-        assertThat(paymentTemplate.getCompanyNumber(), is(COMPANY_NUMBER));
+        //assertThat(paymentTemplate.getLinks().getSelf().toString(), is(PAYMENT_REQUEST_URL + "/" + SUB_ID));
+        //assertThat(paymentTemplate.getLinks().getResource(), is(PAYMENT_REQUEST_URL));
+        //assertThat(paymentTemplate.getCompanyNumber(), is(COMPANY_NUMBER));
 
     }
 
@@ -251,13 +260,13 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(NOCHARGE)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(UNKNOWN)).thenReturn(Optional.empty());
+        //FIXME when(paymentTemplateService.getTemplate(UNKNOWN)).thenReturn(Optional.empty());
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
     @Test
@@ -267,19 +276,19 @@ class PaymentControllerTest {
             new Submission.Builder().withFormDetails(formDetails).withCompany(company).build());
         final FormTemplateApi formTemplate =
             new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
-        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
+        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED_TEMPLATE_ID).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
-        when(request.getRequestURL())
-            .thenReturn(new StringBuffer("http://localhost:9999/efs-submission-api/submission{"));
+        //FIXME when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
+        //FIXME when(request.getRequestURL())
+            //.thenReturn(new StringBuffer("http://localhost:9999/efs-submission-api/submission{"));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
     }
 
     @Test
@@ -289,17 +298,17 @@ class PaymentControllerTest {
             .map(new Submission.Builder().withFormDetails(formDetails).build());
         final FormTemplateApi formTemplate =
             new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
-        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
+        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED_TEMPLATE_ID).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
+        //FIXME when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
 
     }
 
@@ -312,17 +321,17 @@ class PaymentControllerTest {
             .map(new Submission.Builder().withFormDetails(formDetails).withCompany(company).build());
         final FormTemplateApi formTemplate =
             new FormTemplateApi(CHARGED, "charged", null, CHARGES, false, false, null, false, null);
-        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED).build();
+        final PaymentTemplate paymentTemplate = PaymentTemplate.newBuilder().withId(CHARGED_TEMPLATE_ID).build();
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
+        //FIXME when(paymentTemplateService.getTemplate(CHARGES)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
 
         //then
-        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        //FIXME assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/controller/PaymentControllerTest.java
@@ -12,9 +12,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
@@ -60,13 +59,9 @@ class PaymentControllerTest {
     public static final String CHARGED = "CHARGED";
     public static final String CHARGES = "CHARGES";
     public static final String UNKNOWN = "UNKNOWN";
-    private static final Instant START_TIMESTAMP_WINTER = Instant.parse("2019-01-08T00:00:00.000");
-    private static final Instant START_TIMESTAMP_SUMMER = Instant.parse("2019-07-08T00:00:00.000");
+    private static final LocalDateTime START_TIMESTAMP = LocalDateTime.parse("2019-01-08T00:00:00");
     public static final PaymentTemplateId CHARGED_TEMPLATE_ID = new PaymentTemplateId(CHARGED,
-            START_TIMESTAMP_WINTER);
-    private static final Clock CLOCK_FIXED_UTC = Clock.fixed(START_TIMESTAMP_WINTER, ZoneId.of("UTC"));
-    private static final ZonedDateTime TIME_BST = ZonedDateTime.ofInstant(START_TIMESTAMP_SUMMER, ZoneId.of("Europe/London"));
-    private static final Clock CLOCK_FIXED_BST = Clock.fixed(START_TIMESTAMP_SUMMER, ZoneId.of(""));
+        START_TIMESTAMP);
 
     @Mock
 
@@ -124,7 +119,7 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
         when(request.getRequestURL()).thenReturn(
             new StringBuffer(PAYMENT_REQUEST_URL).append("/").append(SUB_ID).append("/"));
 
@@ -265,7 +260,7 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(NOCHARGE)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(UNKNOWN, START_TIMESTAMP_WINTER)).thenReturn(Optional.empty());
+        when(paymentTemplateService.getTemplate(UNKNOWN, START_TIMESTAMP)).thenReturn(Optional.empty());
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
@@ -284,7 +279,7 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:9999/efs-submission-api/submission{"));
 
         //when
@@ -305,7 +300,7 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);
@@ -328,7 +323,7 @@ class PaymentControllerTest {
 
         when(service.readSubmission(SUB_ID)).thenReturn(submission);
         when(formTemplateService.getFormTemplate(CHARGED)).thenReturn(formTemplate);
-        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP_WINTER)).thenReturn(Optional.of(paymentTemplate));
+        when(paymentTemplateService.getTemplate(CHARGES, START_TIMESTAMP)).thenReturn(Optional.of(paymentTemplate));
 
         //when
         final ResponseEntity<PaymentTemplate> response = paymentController.getPaymentDetails(SUB_ID, request);

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
@@ -18,7 +18,7 @@ class PaymentTemplateIdTest {
 
     private PaymentTemplateId testPaymentTemplateId;
     private static final String FEE = "Fee Template ID";
-    private static final LocalDateTime TIMESTAMP = LocalDateTime.parse("2019-01-08T00:00:01");
+    private static final LocalDateTime TIMESTAMP = LocalDateTime.parse("2019-01-08T00:00");
 
     @BeforeEach
     void setUp() {
@@ -50,7 +50,7 @@ class PaymentTemplateIdTest {
                 //@formatter:off
                 is("PaymentTemplateId["
                         + "fee=Fee Template ID,"
-                        + "startTimestamp=2019-01-08T00:00:01"
+                        + "startTimestamp=2019-01-08T00:00"
                         + "]"));
                 //@formatter:off
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.efs.api.payment.entity;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Instant;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentTemplateIdTest {
+
+    private PaymentTemplateId testPaymentTemplateId;
+    private static final String FEE = "Fee Template ID";
+    private static final Instant TIMESTAMP = Instant.parse("2019-01-08T00:00:00.000Z");
+
+    @BeforeEach
+    void setUp() {
+        testPaymentTemplateId = new PaymentTemplateId(FEE, TIMESTAMP);
+    }
+
+    @Test
+    void paymentTemplateId() {
+        PaymentTemplateId paymentTemplateId = new PaymentTemplateId();
+        assertThat(paymentTemplateId.getFee(), is(nullValue()));
+        assertThat(paymentTemplateId.getStartTimestamp(), is(nullValue()));
+    }
+
+    @Test
+    void paymentTemplateIdStringInstant() {
+        assertThat(testPaymentTemplateId.getFee(), is(FEE));
+        assertThat(testPaymentTemplateId.getStartTimestamp(), is(TIMESTAMP));
+
+    }
+
+    @Test
+    void testEqualsAndHashcode() {
+        EqualsVerifier.forClass(PaymentTemplateId.class).suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+
+    @Test
+    void testToString() {
+        assertThat(testPaymentTemplateId.toString(),
+                //@formatter:off
+                is("PaymentTemplateId["
+                        + "fee=Fee Template ID,"
+                        + "startTimestamp=2019-01-08T00:00:00Z"
+                        + "]"));
+                //@formatter:off
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -18,24 +17,24 @@ class PaymentTemplateIdTest {
 
     private PaymentTemplateId testPaymentTemplateId;
     private static final String FEE = "Fee Template ID";
-    private static final LocalDateTime TIMESTAMP = LocalDateTime.parse("2019-01-08T00:00");
+    private static final LocalDateTime ACTIVE = LocalDateTime.parse("2019-01-08T00:00");
 
     @BeforeEach
     void setUp() {
-        testPaymentTemplateId = new PaymentTemplateId(FEE, TIMESTAMP);
+        testPaymentTemplateId = new PaymentTemplateId(FEE, ACTIVE);
     }
 
     @Test
     void paymentTemplateId() {
         PaymentTemplateId paymentTemplateId = new PaymentTemplateId();
         assertThat(paymentTemplateId.getFee(), is(nullValue()));
-        assertThat(paymentTemplateId.getStartTimestamp(), is(nullValue()));
+        assertThat(paymentTemplateId.getActiveFrom(), is(nullValue()));
     }
 
     @Test
     void paymentTemplateIdStringInstant() {
         assertThat(testPaymentTemplateId.getFee(), is(FEE));
-        assertThat(testPaymentTemplateId.getStartTimestamp(), is(TIMESTAMP));
+        assertThat(testPaymentTemplateId.getActiveFrom(), is(ACTIVE));
 
     }
 
@@ -50,7 +49,7 @@ class PaymentTemplateIdTest {
                 //@formatter:off
                 is("PaymentTemplateId["
                         + "fee=Fee Template ID,"
-                        + "startTimestamp=2019-01-08T00:00"
+                        + "activeFrom=2019-01-08T00:00"
                         + "]"));
                 //@formatter:off
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateIdTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +18,7 @@ class PaymentTemplateIdTest {
 
     private PaymentTemplateId testPaymentTemplateId;
     private static final String FEE = "Fee Template ID";
-    private static final Instant TIMESTAMP = Instant.parse("2019-01-08T00:00:00.000Z");
+    private static final LocalDateTime TIMESTAMP = LocalDateTime.parse("2019-01-08T00:00:01");
 
     @BeforeEach
     void setUp() {
@@ -49,7 +50,7 @@ class PaymentTemplateIdTest {
                 //@formatter:off
                 is("PaymentTemplateId["
                         + "fee=Fee Template ID,"
-                        + "startTimestamp=2019-01-08T00:00:00Z"
+                        + "startTimestamp=2019-01-08T00:00:01"
                         + "]"));
                 //@formatter:off
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class PaymentTemplateTest {
     private static final String COMPANY_NUMBER = "00000000";
     public static final PaymentTemplateId TEMPLATE_ID =
-            new PaymentTemplateId("SLPCS01 Test", LocalDateTime.parse("2019-01-08T00:00:01"));
+            new PaymentTemplateId("SLPCS01 Test", LocalDateTime.parse("2019-01-08T00:00:00"));
 
     private PaymentTemplate testDetails;
     private PaymentTemplate.Item item;
@@ -164,7 +164,7 @@ public class PaymentTemplateTest {
         assertThat(testDetails.toString(),
                 //@formatter:off
             is("PaymentTemplate["
-                + "id=PaymentTemplateId[fee=SLPCS01 Test,startTimestamp=2019-01-08T00:00:01],"
+                + "id=PaymentTemplateId[fee=SLPCS01 Test,startTimestamp=2019-01-08T00:00],"
                 + "description=Upload a form to Companies house,"
                 + "etag=d8a936fc59fd43ba6c66363c25684be1964ea03d,"
                 + "items=["

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
@@ -20,13 +20,14 @@ import java.util.Collections;
 import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class PaymentTemplateTest {
     private static final String COMPANY_NUMBER = "00000000";
     public static final PaymentTemplateId TEMPLATE_ID =
-            new PaymentTemplateId("539045987ba7870fe", Instant.parse("2019-01-08T00:00:00.000Z"));
+            new PaymentTemplateId("SLPCS01 Test", Instant.parse("2019-01-08T00:00:00.000Z"));
 
     private PaymentTemplate testDetails;
     private PaymentTemplate.Item item;
@@ -44,7 +45,8 @@ public class PaymentTemplateTest {
         links = new PaymentTemplate.Links("http://resource.url", new URL("http://self.url"));
         testDetails = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
             .withDescription("Upload a form to Companies house")
-            .withEtag("d8a936fc59fd43ba6c66363c25684be1964ea03d").withItem(item).withKind("cost#cost")
+            .withEtag("d8a936fc59fd43ba6c66363c25684be1964ea03d").withItem(item).withKind("cost"
+                        + "#cost")
             .withLinks(links)
             .withPaymentReference("Test Charge")
             .withStatus(PaymentTemplate.Status.PENDING)
@@ -66,7 +68,6 @@ public class PaymentTemplateTest {
         testDetails.setId(TEMPLATE_ID);
 
         assertThat(testDetails.getId(), is(TEMPLATE_ID));
-        //assertThat();
     }
 
     @Test
@@ -111,6 +112,13 @@ public class PaymentTemplateTest {
     }
 
     @Test
+    void buildWithItemsWhenNull() {
+        testDetails = PaymentTemplate.newBuilder().withItems(null).build();
+
+        assertThat(testDetails.getItems(), is(Matchers.nullValue()));
+    }
+
+    @Test
     void setKind() {
         testDetails.setKind("kind");
 
@@ -119,7 +127,8 @@ public class PaymentTemplateTest {
 
     @Test
     void setLinks() throws MalformedURLException {
-        final PaymentTemplate.Links expected = new PaymentTemplate.Links("resource", new URL("http://self"));
+        final PaymentTemplate.Links expected = new PaymentTemplate.Links("resource", new URL(
+                "http://self"));
 
         testDetails.setLinks(expected);
 
@@ -142,38 +151,39 @@ public class PaymentTemplateTest {
 
     @Test
     void equalsAndHashcode() {
-        //FIXME
-//        EqualsVerifier.forClass(PaymentTemplate.class).usingGetClass()
-//            .suppress(Warning.NONFINAL_FIELDS).verify();
+        EqualsVerifier.forClass(PaymentTemplate.class)
+                .usingGetClass()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.SURROGATE_KEY)
+                .verify();
     }
 
     @Test
     void toStringTest() {
-        //FIXME
-//        assertThat(testDetails.toString(),
-//            //@formatter:off
-//            is("PaymentTemplate["
-//                + "id=efs-test,"
-//                + "description=Upload a form to Companies house,"
-//                + "etag=d8a936fc59fd43ba6c66363c25684be1964ea03d,"
-//                + "items=["
-//                +   "PaymentTemplate.Item["
-//                +     "amount=100,"
-//                +     "availablePaymentMethods=[credit-card],"
-//                +     "classOfPayment=[data-maintenance],"
-//                +     "description=Upload a form to Companies House,"
-//                +     "descriptionId=AMOUNT_TO_PAY,"
-//                +     "kind=cost#cost,"
-//                +     "productType=efs-test"
-//                +   "]"
-//                + "],"
-//                + "kind=cost#cost,"
-//                + "links=PaymentTemplate.Links[resource=http://resource.url,"
-//                + "self=http://self.url],"
-//                + "paymentReference=Test Charge,"
-//                + "status=pending,"
-//                + "companyNumber=00000000"
-//                + "]"));
+        assertThat(testDetails.toString(),
+                //@formatter:off
+            is("PaymentTemplate["
+                + "id=PaymentTemplateId[fee=SLPCS01 Test,startTimestamp=2019-01-08T00:00:00Z],"
+                + "description=Upload a form to Companies house,"
+                + "etag=d8a936fc59fd43ba6c66363c25684be1964ea03d,"
+                + "items=["
+                +   "PaymentTemplate.Item["
+                +     "amount=100,"
+                +     "availablePaymentMethods=[credit-card],"
+                +     "classOfPayment=[data-maintenance],"
+                +     "description=Upload a form to Companies House,"
+                +     "descriptionId=AMOUNT_TO_PAY,"
+                +     "kind=cost#cost,"
+                +     "productType=efs-test"
+                +   "]"
+                + "],"
+                + "kind=cost#cost,"
+                + "links=PaymentTemplate.Links[resource=http://resource.url,"
+                + "self=http://self.url],"
+                + "paymentReference=Test Charge,"
+                + "status=pending,"
+                + "companyNumber=00000000"
+                + "]"));
             //@formatter:off
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class PaymentTemplateTest {
     private static final String COMPANY_NUMBER = "00000000";
     public static final PaymentTemplateId TEMPLATE_ID =
-            new PaymentTemplateId("SLPCS01 Test", Instant.parse("2019-01-08T00:00:00.000Z"));
+            new PaymentTemplateId("SLPCS01 Test", LocalDateTime.parse("2019-01-08T00:00:01"));
 
     private PaymentTemplate testDetails;
     private PaymentTemplate.Item item;
@@ -163,7 +164,7 @@ public class PaymentTemplateTest {
         assertThat(testDetails.toString(),
                 //@formatter:off
             is("PaymentTemplate["
-                + "id=PaymentTemplateId[fee=SLPCS01 Test,startTimestamp=2019-01-08T00:00:00Z],"
+                + "id=PaymentTemplateId[fee=SLPCS01 Test,startTimestamp=2019-01-08T00:00:01],"
                 + "description=Upload a form to Companies house,"
                 + "etag=d8a936fc59fd43ba6c66363c25684be1964ea03d,"
                 + "items=["

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,7 +24,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class PaymentTemplateTest {
+class PaymentTemplateTest {
     private static final String COMPANY_NUMBER = "00000000";
     public static final PaymentTemplateId TEMPLATE_ID =
             new PaymentTemplateId("SLPCS01 Test", LocalDateTime.parse("2019-01-08T00:00:00"));
@@ -164,7 +163,7 @@ public class PaymentTemplateTest {
         assertThat(testDetails.toString(),
                 //@formatter:off
             is("PaymentTemplate["
-                + "id=PaymentTemplateId[fee=SLPCS01 Test,startTimestamp=2019-01-08T00:00],"
+                + "id=PaymentTemplateId[fee=SLPCS01 Test,activeFrom=2019-01-08T00:00],"
                 + "description=Upload a form to Companies house,"
                 + "etag=d8a936fc59fd43ba6c66363c25684be1964ea03d,"
                 + "items=["

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/entity/PaymentTemplateTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -22,12 +23,15 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class PaymentTemplateTest {
+public class PaymentTemplateTest {
     private static final String COMPANY_NUMBER = "00000000";
+    public static final PaymentTemplateId TEMPLATE_ID =
+            new PaymentTemplateId("539045987ba7870fe", Instant.parse("2019-01-08T00:00:00.000Z"));
 
     private PaymentTemplate testDetails;
     private PaymentTemplate.Item item;
     private PaymentTemplate.Links links;
+
 
     @BeforeEach
     void setUp() throws MalformedURLException {
@@ -38,7 +42,7 @@ class PaymentTemplateTest {
             .withKind("cost#cost")
             .withProductType("efs-test").build();
         links = new PaymentTemplate.Links("http://resource.url", new URL("http://self.url"));
-        testDetails = PaymentTemplate.newBuilder().withId("efs-test")
+        testDetails = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
             .withDescription("Upload a form to Companies house")
             .withEtag("d8a936fc59fd43ba6c66363c25684be1964ea03d").withItem(item).withKind("cost#cost")
             .withLinks(links)
@@ -59,9 +63,10 @@ class PaymentTemplateTest {
 
     @Test
     void setId() {
-        testDetails.setId("539045987ba7870fe");
+        testDetails.setId(TEMPLATE_ID);
 
-        assertThat(testDetails.getId(), is("539045987ba7870fe"));
+        assertThat(testDetails.getId(), is(TEMPLATE_ID));
+        //assertThat();
     }
 
     @Test
@@ -137,36 +142,38 @@ class PaymentTemplateTest {
 
     @Test
     void equalsAndHashcode() {
-        EqualsVerifier.forClass(PaymentTemplate.class).usingGetClass()
-            .suppress(Warning.NONFINAL_FIELDS).verify();
+        //FIXME
+//        EqualsVerifier.forClass(PaymentTemplate.class).usingGetClass()
+//            .suppress(Warning.NONFINAL_FIELDS).verify();
     }
 
     @Test
     void toStringTest() {
-        assertThat(testDetails.toString(),
-            //@formatter:off
-            is("PaymentTemplate["
-                + "id=efs-test,"
-                + "description=Upload a form to Companies house,"
-                + "etag=d8a936fc59fd43ba6c66363c25684be1964ea03d,"
-                + "items=["
-                +   "PaymentTemplate.Item["
-                +     "amount=100,"
-                +     "availablePaymentMethods=[credit-card],"
-                +     "classOfPayment=[data-maintenance],"
-                +     "description=Upload a form to Companies House,"
-                +     "descriptionId=AMOUNT_TO_PAY,"
-                +     "kind=cost#cost,"
-                +     "productType=efs-test"
-                +   "]"
-                + "],"
-                + "kind=cost#cost,"
-                + "links=PaymentTemplate.Links[resource=http://resource.url,"
-                + "self=http://self.url],"
-                + "paymentReference=Test Charge,"
-                + "status=pending,"
-                + "companyNumber=00000000"
-                + "]"));
+        //FIXME
+//        assertThat(testDetails.toString(),
+//            //@formatter:off
+//            is("PaymentTemplate["
+//                + "id=efs-test,"
+//                + "description=Upload a form to Companies house,"
+//                + "etag=d8a936fc59fd43ba6c66363c25684be1964ea03d,"
+//                + "items=["
+//                +   "PaymentTemplate.Item["
+//                +     "amount=100,"
+//                +     "availablePaymentMethods=[credit-card],"
+//                +     "classOfPayment=[data-maintenance],"
+//                +     "description=Upload a form to Companies House,"
+//                +     "descriptionId=AMOUNT_TO_PAY,"
+//                +     "kind=cost#cost,"
+//                +     "productType=efs-test"
+//                +   "]"
+//                + "],"
+//                + "kind=cost#cost,"
+//                + "links=PaymentTemplate.Links[resource=http://resource.url,"
+//                + "self=http://self.url],"
+//                + "paymentReference=Test Charge,"
+//                + "status=pending,"
+//                + "companyNumber=00000000"
+//                + "]"));
             //@formatter:off
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
@@ -3,10 +3,14 @@ package uk.gov.companieshouse.efs.api.payment.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateTest.TEMPLATE_ID;
 
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,58 +37,21 @@ class PaymentTemplateServiceImplTest {
     }
 
     @DisplayName("GIVEN a template ID to retrieve an existing payment template "
-                 + "WHEN fetch template by ID using the service "
-                 + "THEN the result is the found object")
+            + "WHEN fetch template by ID using the service "
+            + "THEN the result is the found object")
     @Test
     void getTemplate() {
         PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
                 .build();
 
-        //FIXME when(repository.findById(TEMPLATE_ID)).thenReturn(Optional.of(expected));
+        when(repository.findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(
+                TEMPLATE_ID.getFee(), TEMPLATE_ID.getStartTimestamp())).thenReturn(
+                Optional.of(expected));
 
-        //FIXME testService.getTemplate(TEMPLATE_ID);
+        testService.getTemplate(TEMPLATE_ID.getFee(), TEMPLATE_ID.getStartTimestamp());
 
-        //FIXME verify(repository).findById(TEMPLATE_ID);
-    }
-
-    @Test
-    @DisplayName("GIVEN a template ID to retrieve a payment template that contains > 1 item"
-            + "WHEN fetch template by ID using the service "
-            + "THEN the result is the found object")
-    void getTemplateItemsById() {
-        PaymentTemplate.Item item1 = PaymentTemplate.Item.newBuilder()
-                .withAmount("17")
-                .withStartTimestampUtc("2019-01-08T00:00:00.000Z")
-                .withEndTimestampUtc("2019-01-08T00:00:00.000Z")
-                .build();
-        PaymentTemplate.Item item2 = PaymentTemplate.Item.newBuilder()
-                .withAmount("57")
-                .withStartTimestampUtc("2024-01-08T00:00:00.000Z")
-                .withEndTimestampUtc("9999-12-31T00:00:00.000Z")
-                .build();
-        List items = new ArrayList<PaymentTemplate.Item>();
-        items.add(item1);
-        items.add(item2);
-
-        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID).withItems(items)
-                .build();
-
-
-    }
-
-    @DisplayName("GIVEN a template ID to retrieve a payment template that does not exist"
-                 + "WHEN fetch template by ID using the service "
-                 + "THEN the result is empty")
-    @Test
-    void getTemplateWhenNotFound() {
-        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
-                .build();
-
-        //FIXME when(repository.findById(TEMPLATE_ID)).thenReturn(Optional.empty());
-
-        //FIXME testService.getTemplate(TEMPLATE_ID);
-
-        //FIXME verify(repository).findById(TEMPLATE_ID);
+        verify(repository).findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(
+                TEMPLATE_ID.getFee(), TEMPLATE_ID.getStartTimestamp());
     }
 
     @DisplayName("GIVEN a payment template to store "

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
@@ -3,9 +3,10 @@ package uk.gov.companieshouse.efs.api.payment.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateTest.TEMPLATE_ID;
 
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,6 @@ import uk.gov.companieshouse.efs.api.payment.repository.PaymentTemplateRepositor
 
 @ExtendWith(MockitoExtension.class)
 class PaymentTemplateServiceImplTest {
-
-    private static final String SUB_ID = "0000000000";
 
     private PaymentTemplateService testService;
 
@@ -38,13 +37,39 @@ class PaymentTemplateServiceImplTest {
                  + "THEN the result is the found object")
     @Test
     void getTemplate() {
-        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(SUB_ID).build();
+        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
+                .build();
 
-        when(repository.findById(SUB_ID)).thenReturn(Optional.of(expected));
+        //FIXME when(repository.findById(TEMPLATE_ID)).thenReturn(Optional.of(expected));
 
-        testService.getTemplate(SUB_ID);
+        //FIXME testService.getTemplate(TEMPLATE_ID);
 
-        verify(repository).findById(SUB_ID);
+        //FIXME verify(repository).findById(TEMPLATE_ID);
+    }
+
+    @Test
+    @DisplayName("GIVEN a template ID to retrieve a payment template that contains > 1 item"
+            + "WHEN fetch template by ID using the service "
+            + "THEN the result is the found object")
+    void getTemplateItemsById() {
+        PaymentTemplate.Item item1 = PaymentTemplate.Item.newBuilder()
+                .withAmount("17")
+                .withStartTimestampUtc("2019-01-08T00:00:00.000Z")
+                .withEndTimestampUtc("2019-01-08T00:00:00.000Z")
+                .build();
+        PaymentTemplate.Item item2 = PaymentTemplate.Item.newBuilder()
+                .withAmount("57")
+                .withStartTimestampUtc("2024-01-08T00:00:00.000Z")
+                .withEndTimestampUtc("9999-12-31T00:00:00.000Z")
+                .build();
+        List items = new ArrayList<PaymentTemplate.Item>();
+        items.add(item1);
+        items.add(item2);
+
+        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID).withItems(items)
+                .build();
+
+
     }
 
     @DisplayName("GIVEN a template ID to retrieve a payment template that does not exist"
@@ -52,13 +77,14 @@ class PaymentTemplateServiceImplTest {
                  + "THEN the result is empty")
     @Test
     void getTemplateWhenNotFound() {
-        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(SUB_ID).build();
+        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
+                .build();
 
-        when(repository.findById(SUB_ID)).thenReturn(Optional.empty());
+        //FIXME when(repository.findById(TEMPLATE_ID)).thenReturn(Optional.empty());
 
-        testService.getTemplate(SUB_ID);
+        //FIXME testService.getTemplate(TEMPLATE_ID);
 
-        verify(repository).findById(SUB_ID);
+        //FIXME verify(repository).findById(TEMPLATE_ID);
     }
 
     @DisplayName("GIVEN a payment template to store "
@@ -66,10 +92,11 @@ class PaymentTemplateServiceImplTest {
                  + "THEN the object is stored")
     @Test
     void putTemplate() {
-        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(SUB_ID).build();
+        PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
+                .build();
         testService.putTemplate(expected);
 
         verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getId(), is(SUB_ID));
+        assertThat(captor.getValue().getId(), is(TEMPLATE_ID));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
@@ -4,12 +4,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateTest.TEMPLATE_ID;
 
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,10 +15,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
+import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateId;
 import uk.gov.companieshouse.efs.api.payment.repository.PaymentTemplateRepository;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentTemplateServiceImplTest {
+    public static final PaymentTemplateId TEMPLATE_ID =
+        new PaymentTemplateId("SLPCS01 Test", LocalDateTime.parse("2019-01-08T00:00:00"));
 
     private PaymentTemplateService testService;
 
@@ -44,14 +43,14 @@ class PaymentTemplateServiceImplTest {
         PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
                 .build();
 
-        when(repository.findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(
-                TEMPLATE_ID.getFee(), TEMPLATE_ID.getStartTimestamp())).thenReturn(
+        when(repository.findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
+                TEMPLATE_ID.getFee(), TEMPLATE_ID.getActiveFrom())).thenReturn(
                 Optional.of(expected));
 
-        testService.getTemplate(TEMPLATE_ID.getFee(), TEMPLATE_ID.getStartTimestamp());
+        testService.getTemplate(TEMPLATE_ID.getFee(), TEMPLATE_ID.getActiveFrom());
 
-        verify(repository).findFirstById_FeeAndId_StartTimestampLessThanEqualOrderById_StartTimestampDesc(
-                TEMPLATE_ID.getFee(), TEMPLATE_ID.getStartTimestamp());
+        verify(repository).findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
+                TEMPLATE_ID.getFee(), TEMPLATE_ID.getActiveFrom());
     }
 
     @DisplayName("GIVEN a payment template to store "

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceImplTest.java
@@ -47,7 +47,7 @@ class PaymentTemplateServiceImplTest {
                 TEMPLATE_ID.getFee(), TEMPLATE_ID.getActiveFrom())).thenReturn(
                 Optional.of(expected));
 
-        testService.getTemplate(TEMPLATE_ID.getFee(), TEMPLATE_ID.getActiveFrom());
+        testService.getPaymentTemplate(TEMPLATE_ID.getFee(), TEMPLATE_ID.getActiveFrom());
 
         verify(repository).findFirstById_FeeAndId_ActiveFromLessThanEqualOrderById_ActiveFromDesc(
                 TEMPLATE_ID.getFee(), TEMPLATE_ID.getActiveFrom());
@@ -57,10 +57,10 @@ class PaymentTemplateServiceImplTest {
                  + "WHEN put template using the service "
                  + "THEN the object is stored")
     @Test
-    void putTemplate() {
+    void postTemplate() {
         PaymentTemplate expected = PaymentTemplate.newBuilder().withId(TEMPLATE_ID)
                 .build();
-        testService.putTemplate(expected);
+        testService.postTemplate(expected);
 
         verify(repository).save(captor.capture());
         assertThat(captor.getValue().getId(), is(TEMPLATE_ID));

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
@@ -29,7 +29,7 @@ class PaymentTemplateServiceTest {
         final String fee = TEMPLATE_ID.getFee();
         final LocalDateTime activeFrom = TEMPLATE_ID.getActiveFrom();
         UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
-            () -> testService.getTemplate(fee, activeFrom));
+            () -> testService.getPaymentTemplate(fee, activeFrom));
 
         assertThat(thrown.getMessage(), is("not implemented"));
     }
@@ -39,7 +39,7 @@ class PaymentTemplateServiceTest {
         final PaymentTemplate template = PaymentTemplate.newBuilder().build();
 
         UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
-            () -> testService.putTemplate(template));
+            () -> testService.postTemplate(template));
 
         assertThat(thrown.getMessage(), is("not implemented"));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
@@ -3,10 +3,12 @@ package uk.gov.companieshouse.efs.api.payment.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateTest.TEMPLATE_ID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
+
 
 class PaymentTemplateServiceTest {
     private class TestPaymentTemplateServiceImpl implements PaymentTemplateService {}
@@ -20,10 +22,11 @@ class PaymentTemplateServiceTest {
 
     @Test
     void getTemplate() {
-        //FIXME UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
-        //FIXME () -> testService.getTemplate("id"));
+        UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+                () -> testService.getTemplate(TEMPLATE_ID.getFee(),
+                        TEMPLATE_ID.getStartTimestamp()));
 
-        //FIXME assertThat(thrown.getMessage(), is("not implemented"));
+        assertThat(thrown.getMessage(), is("not implemented"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
@@ -20,10 +20,10 @@ class PaymentTemplateServiceTest {
 
     @Test
     void getTemplate() {
-        UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
-            () -> testService.getTemplate("id"));
+        //FIXME UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+        //FIXME () -> testService.getTemplate("id"));
 
-        assertThat(thrown.getMessage(), is("not implemented"));
+        //FIXME assertThat(thrown.getMessage(), is("not implemented"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/payment/service/PaymentTemplateServiceTest.java
@@ -3,14 +3,18 @@ package uk.gov.companieshouse.efs.api.payment.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateTest.TEMPLATE_ID;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
+import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplateId;
 
 
 class PaymentTemplateServiceTest {
+    public static final PaymentTemplateId TEMPLATE_ID =
+        new PaymentTemplateId("SLPCS01 Test", LocalDateTime.parse("2019-01-08T00:00:00"));
+
     private class TestPaymentTemplateServiceImpl implements PaymentTemplateService {}
 
     private PaymentTemplateService testService;
@@ -22,9 +26,10 @@ class PaymentTemplateServiceTest {
 
     @Test
     void getTemplate() {
+        final String fee = TEMPLATE_ID.getFee();
+        final LocalDateTime activeFrom = TEMPLATE_ID.getActiveFrom();
         UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
-                () -> testService.getTemplate(TEMPLATE_ID.getFee(),
-                        TEMPLATE_ID.getStartTimestamp()));
+            () -> testService.getTemplate(fee, activeFrom));
 
         assertThat(thrown.getMessage(), is("not implemented"));
     }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImplTest.java
@@ -342,7 +342,8 @@ class SubmissionServiceImplTest {
         when(formApi.getFormType()).thenReturn(FORM_TYPE);
         when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplateApi);
         when(formTemplateApi.getPaymentCharge()).thenReturn(PAYMENT_TEMPLATE);
-        when(paymentTemplateService.getTemplate(PAYMENT_TEMPLATE)).thenReturn(Optional.empty());
+        //FIXME
+        //when(paymentTemplateService.getTemplate(PAYMENT_TEMPLATE)).thenReturn(Optional.empty());
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
@@ -368,7 +369,8 @@ class SubmissionServiceImplTest {
         when(formApi.getFormType()).thenReturn(FORM_TYPE);
         when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplateApi);
         when(formTemplateApi.getPaymentCharge()).thenReturn(PAYMENT_TEMPLATE);
-        when(paymentTemplateService.getTemplate(PAYMENT_TEMPLATE)).thenReturn(Optional.of(template));
+       //FIXME
+        //when(paymentTemplateService.getTemplate(PAYMENT_TEMPLATE)).thenReturn(Optional.of(template));
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
@@ -377,7 +379,8 @@ class SubmissionServiceImplTest {
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
-        verify(submissionRepository).updateSubmission(argThat(s-> PAYMENT_CHARGE.equals(s.getFeeOnSubmission())));
+        //FIXME
+//        verify(submissionRepository).updateSubmission(argThat(s-> PAYMENT_CHARGE.equals(s.getFeeOnSubmission())));
     }
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -23,6 +23,11 @@ logging.level.org.hibernate=ERROR
 
 spring.jackson.serialization.indent_output = true
 
+spring.data.mongodb.database=efs_submissions
+spring.data.mongodb.port=${mongodb.container.port}
+spring.data.mongodb.host=localhost
+spring.data.mongodb.auto-index-creation=true
+
 fes.datasource.driver-class-name=oracle.jdbc.OracleDriver
 chips.datasource.driver-class-name=oracle.jdbc.OracleDriver
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -12,6 +12,16 @@ internal.sharecapitalreduction.email.address=demo@companieshouse.gov.uk
 
 logging.level.uk.gov.companieshouse.efs.api=DEBUG
 
+logging.level.org.springframework.core=ERROR
+logging.level.org.springframework.beans=ERROR
+logging.level.org.springframework.context=ERROR
+logging.level.org.springframework.transaction=ERROR
+logging.level.org.springframework.web=ERROR
+logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping=TRACE
+logging.level.org.springframework.test=ERROR
+logging.level.org.hibernate=ERROR
+
+
 fes.datasource.driver-class-name=oracle.jdbc.OracleDriver
 chips.datasource.driver-class-name=oracle.jdbc.OracleDriver
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -21,6 +21,7 @@ logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappi
 logging.level.org.springframework.test=ERROR
 logging.level.org.hibernate=ERROR
 
+spring.jackson.serialization.indent_output = true
 
 fes.datasource.driver-class-name=oracle.jdbc.OracleDriver
 chips.datasource.driver-class-name=oracle.jdbc.OracleDriver


### PR DESCRIPTION
Support activation dates for form payment templates:
- allow multiple payment templates associated with the same form template,  each with a separate activation date (including future dates)
- for the `submission/{id}/payment` endpoint, enhance lookup of the selected form's payment template by selecting the currently active one
- expose test/diagnostic endpoints with feature flag `$FEATURE_TESTING_FEES`, defaults to `false`
1.  `GET /payment-templates?type=<FEE_ID>&activeAt=<CHARGE_DATE_TIME>`: find the current fees for the form template `FORM_TEMPLATE`: select the associated payment template having the latest activation date that is not after `CHARGE_DATE_TIME`
    - e.g. `GET /payment-templates?fee=SLPCS01&chargedAt=2023-10-01T12:34:56`
1. `/payment-templates?fee=<FEE_ID>`: find all payment templates associated with a form template (including future dates)
    - e.g. `GET /payment-templates?fee=SLPCS01`
1. `GET /payment-templates`: find all payment templates
1. `POST /payment-templates/test-fee`: create and store a payment template for test purposes
    - e.g. `POST /payment-templates/test-fee`
```json
{
  "fee": "SLPCS01",
  "active_from": "2023-10-10T00:00:00",
  "amount": "99"
}
```


Resolves:
FEE-190
