### PR TITLE
Fix incorrect maintenance screen displayed in EFS Web

### DIFF
--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -791,21 +791,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK - no ongoing maintenance now",
-            "schema": {
-              "$ref": "#/definitions/maintenanceStatus"
-            },
-            "examples": {
-              "application/json": {
-                "status": "UP",
-                "message": "Planned maintenance has been configured",
-                "maintenance_start_time": "2023-11-13T05:10:00Z",
-                "maintenance_end_time": "2023-11-13T18:00:00Z"
-              }
-            }
-          },
-          "503": {
-            "description": "SERVICE UNAVAILABLE - Planned maintenance is ongoing now",
+            "description": "OK - maintenance check successful",
             "schema": {
               "$ref": "#/definitions/maintenanceStatus"
             },

--- a/src/test/java/uk/gov/companieshouse/efs/api/maintenance/MaintenanceActuatorEndpointTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/maintenance/MaintenanceActuatorEndpointTest.java
@@ -49,11 +49,10 @@ class MaintenanceActuatorEndpointTest {
     void resultWhenTimesAreBlank(final String start, final String end, final String message) {
         setupPeriodConfigValues(start, end, message);
 
-        final ResponseEntity<MaintenanceCheckApi> resultNow = testEndpoint.check();
+        final MaintenanceCheckApi resultNow = testEndpoint.check();
 
-        assertThat(resultNow.getStatusCode(), is(HttpStatus.OK));
-        assertThat(resultNow.getBody().getStatus(), is(ServiceStatus.UP));
-        assertThat(resultNow.getBody().getMessage(), is("No planned maintenance is configured"));
+        assertThat(resultNow.getStatus(), is(ServiceStatus.UP));
+        assertThat(resultNow.getMessage(), is("No planned maintenance is configured"));
 
     }
 
@@ -61,13 +60,12 @@ class MaintenanceActuatorEndpointTest {
     void checkWhenPeriodSetForFuture() {
         setupPeriodConfigValues("3 Jan 24 00:30 GMT", "3 Jan 24 02:30 GMT", null);
 
-        final ResponseEntity<MaintenanceCheckApi> resultNow = testEndpoint.check();
+        final MaintenanceCheckApi resultNow = testEndpoint.check();
 
-        assertThat(resultNow.getStatusCode(), is(HttpStatus.OK));
-        assertThat(resultNow.getBody().getStatus(), is(ServiceStatus.UP));
-        assertThat(resultNow.getBody().getMessage(), is("Planned maintenance has been configured"));
-        assertThat(resultNow.getBody().getMaintenanceStart(), is("2024-01-03T00:30:00Z"));
-        assertThat(resultNow.getBody().getMaintenanceEnd(), is("2024-01-03T02:30:00Z"));
+        assertThat(resultNow.getStatus(), is(ServiceStatus.UP));
+        assertThat(resultNow.getMessage(), is("Planned maintenance has been configured"));
+        assertThat(resultNow.getMaintenanceStart(), is("2024-01-03T00:30:00Z"));
+        assertThat(resultNow.getMaintenanceEnd(), is("2024-01-03T02:30:00Z"));
 
     }
 
@@ -75,13 +73,12 @@ class MaintenanceActuatorEndpointTest {
     void checkWhenPeriodSetForPast() {
         setupPeriodConfigValues("3 Dec 23 00:30 GMT", "3 Dec 23 02:30 GMT", null);
 
-        final ResponseEntity<MaintenanceCheckApi> resultNow = testEndpoint.check();
+        final MaintenanceCheckApi resultNow = testEndpoint.check();
 
-        assertThat(resultNow.getStatusCode(), is(HttpStatus.OK));
-        assertThat(resultNow.getBody().getStatus(), is(ServiceStatus.UP));
-        assertThat(resultNow.getBody().getMessage(), is("Planned maintenance has been configured"));
-        assertThat(resultNow.getBody().getMaintenanceStart(), is("2023-12-03T00:30:00Z"));
-        assertThat(resultNow.getBody().getMaintenanceEnd(), is("2023-12-03T02:30:00Z"));
+        assertThat(resultNow.getStatus(), is(ServiceStatus.UP));
+        assertThat(resultNow.getMessage(), is("Planned maintenance has been configured"));
+        assertThat(resultNow.getMaintenanceStart(), is("2023-12-03T00:30:00Z"));
+        assertThat(resultNow.getMaintenanceEnd(), is("2023-12-03T02:30:00Z"));
 
     }
 
@@ -90,13 +87,12 @@ class MaintenanceActuatorEndpointTest {
         setupPeriodConfigValues("25 Dec 23 00:30 GMT", "25 Dec 23 02:30 GMT",
             "UNAVAILABLE - PLANNED MAINTENANCE");
 
-        final ResponseEntity<MaintenanceCheckApi> resultNow = testEndpoint.check();
+        final MaintenanceCheckApi resultNow = testEndpoint.check();
 
-        assertThat(resultNow.getStatusCode(), is(HttpStatus.SERVICE_UNAVAILABLE));
-        assertThat(resultNow.getBody().getStatus(), is(ServiceStatus.OUT_OF_SERVICE));
-        assertThat(resultNow.getBody().getMessage(), is("UNAVAILABLE - PLANNED MAINTENANCE"));
-        assertThat(resultNow.getBody().getMaintenanceStart(), is("2023-12-25T00:30:00Z"));
-        assertThat(resultNow.getBody().getMaintenanceEnd(), is("2023-12-25T02:30:00Z"));
+        assertThat(resultNow.getStatus(), is(ServiceStatus.OUT_OF_SERVICE));
+        assertThat(resultNow.getMessage(), is("UNAVAILABLE - PLANNED MAINTENANCE"));
+        assertThat(resultNow.getMaintenanceStart(), is("2023-12-25T00:30:00Z"));
+        assertThat(resultNow.getMaintenanceEnd(), is("2023-12-25T02:30:00Z"));
 
     }
 
@@ -105,17 +101,16 @@ class MaintenanceActuatorEndpointTest {
         setupPeriodConfigValues("25 Dec 23 00:30", "25 Dec 23 02:30 GMT",
             "UNAVAILABLE - PLANNED MAINTENANCE");
 
-        final ResponseEntity<MaintenanceCheckApi> resultNow = testEndpoint.check();
+        final MaintenanceCheckApi resultNow = testEndpoint.check();
 
-        assertThat(resultNow.getStatusCode(), is(HttpStatus.OK));
-        assertThat(resultNow.getBody().getStatus(), is(ServiceStatus.UP));
-        assertThat(resultNow.getBody().getMessage(),
+        assertThat(resultNow.getStatus(), is(ServiceStatus.UP));
+        assertThat(resultNow.getMessage(),
             is("Error parsing configuration: PLANNED_MAINTENANCE_START_TIME: Text '25 Dec 23 " +
                 "00:30' could not be parsed: Unable to obtain ZonedDateTime from " +
                 "TemporalAccessor: {},ISO resolved to 2023-12-25T00:30 of type java.time.format"
                 + ".Parsed"));
-        assertThat(resultNow.getBody().getMaintenanceStart(), is("25 Dec 23 00:30"));
-        assertThat(resultNow.getBody().getMaintenanceEnd(), is("25 Dec 23 02:30 GMT"));
+        assertThat(resultNow.getMaintenanceStart(), is("25 Dec 23 00:30"));
+        assertThat(resultNow.getMaintenanceEnd(), is("25 Dec 23 02:30 GMT"));
     }
 
     @Test
@@ -123,15 +118,14 @@ class MaintenanceActuatorEndpointTest {
         setupPeriodConfigValues("25 Dec 23 00:30 GMT", "5 Jan 24 02:30+01",
             "UNAVAILABLE - PLANNED MAINTENANCE");
 
-        final ResponseEntity<MaintenanceCheckApi> resultNow = testEndpoint.check();
+        final MaintenanceCheckApi resultNow = testEndpoint.check();
 
-        assertThat(resultNow.getStatusCode(), is(HttpStatus.OK));
-        assertThat(resultNow.getBody().getStatus(), is(ServiceStatus.UP));
-        assertThat(resultNow.getBody().getMessage(),
+        assertThat(resultNow.getStatus(), is(ServiceStatus.UP));
+        assertThat(resultNow.getMessage(),
             is("Error parsing configuration: PLANNED_MAINTENANCE_END_TIME: Text '5 Jan 24 " + "02"
                 + ":30+01' could not be parsed, unparsed text found at index 14"));
-        assertThat(resultNow.getBody().getMaintenanceStart(), is("2023-12-25T00:30:00Z"));
-        assertThat(resultNow.getBody().getMaintenanceEnd(), is("5 Jan 24 02:30+01"));
+        assertThat(resultNow.getMaintenanceStart(), is("2023-12-25T00:30:00Z"));
+        assertThat(resultNow.getMaintenanceEnd(), is("5 Jan 24 02:30+01"));
     }
 
     @Test
@@ -139,15 +133,14 @@ class MaintenanceActuatorEndpointTest {
         setupPeriodConfigValues("", "5 Jan 24 02:30+01",
             "UNAVAILABLE - PLANNED MAINTENANCE");
 
-        final ResponseEntity<MaintenanceCheckApi> resultNow = testEndpoint.check();
+        final MaintenanceCheckApi resultNow = testEndpoint.check();
 
-        assertThat(resultNow.getStatusCode(), is(HttpStatus.OK));
-        assertThat(resultNow.getBody().getStatus(), is(ServiceStatus.UP));
-        assertThat(resultNow.getBody().getMessage(),
+        assertThat(resultNow.getStatus(), is(ServiceStatus.UP));
+        assertThat(resultNow.getMessage(),
             is("Error parsing configuration: PLANNED_MAINTENANCE_END_TIME: Text '5 Jan 24 " + "02"
                 + ":30+01' could not be parsed, unparsed text found at index 14"));
-        assertThat(resultNow.getBody().getMaintenanceStart(), is(nullValue()));
-        assertThat(resultNow.getBody().getMaintenanceEnd(), is("5 Jan 24 02:30+01"));
+        assertThat(resultNow.getMaintenanceStart(), is(nullValue()));
+        assertThat(resultNow.getMaintenanceEnd(), is("5 Jan 24 02:30+01"));
     }
 
     private void setupPeriodConfigValues(final String start, final String end,


### PR DESCRIPTION
Maintenance check response code should always be 200 OK, even during planned maintenance periods. Response 503 SERVICE UNAVAILABLE causing wrong screen to display in EFS Web.