### PR TITLE
Add sequential order index to Scottish Liq forms

### DIFF
--- a/src/main/resources/form_templates.json
+++ b/src/main/resources/form_templates.json
@@ -2355,7 +2355,7 @@
   "_id" : "LIQ13(Scot)",
   "formName" : "LIQ13 (Scot) - Final account prior to dissolution in MVL",
   "formCategory" : "INSSC2018_VL",
-  "orderIndex": 1,
+  "orderIndex": 2,
   "fee" : "",
   "isAuthenticationRequired" : true,
   "isFesEnabled" : true
@@ -2363,7 +2363,7 @@
   "_id" : "LIQ14(Scot)",
   "formName" : "LIQ14 (Scot) - Final account prior to dissolution in CVL",
   "formCategory" : "INSSC2018_VL",
-  "orderIndex": 1,
+  "orderIndex": 3,
   "fee" : "",
   "isAuthenticationRequired" : true,
   "isFesEnabled" : true
@@ -2371,7 +2371,7 @@
   "_id" : "LIQ15(Scot)",
   "formName" : "LIQ15 (Scot) - Notice of a court order staying or sisting proceedings in a CVL or MVL winding up",
   "formCategory" : "INSSC2018_VL",
-  "orderIndex": 1,
+  "orderIndex": 4,
   "fee" : "",
   "isAuthenticationRequired" : true,
   "isFesEnabled" : true


### PR DESCRIPTION
This is for this screen:

<img width="543" alt="Screenshot 2023-11-23 at 10 27 53 am" src="https://github.com/companieshouse/efs-submission-api/assets/2736331/23e88336-6bb5-449f-a181-4c75a41ecf88">

or this can be called `https://internalapi.tcats1.aws.chdev.org/efs-submission-api/form-templates?category=INSSC2018_VL`

BI-13477