### PR TITLE
Repoint Makefile at dep-check-suppressions/main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,7 @@ artifact_name       := efs-submission-api
 version             := unversioned
 
 dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-
-# dependency_check_suppressions_repo_branch
-# The branch of the dependency-check-suppressions repository to use
-# as the source of the suppressions file.
-# This should point to "main" branch when being used for release,
-# but can point to a different branch for experimentation/development.
-dependency_check_suppressions_repo_branch:=feature/suppressions-for-company-accounts-api
-
+dependency_check_suppressions_repo_branch:=main
 dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-      <dependencies>
+    <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.11</version>
         <relativePath/>
     </parent>
     <artifactId>efs-submission-api</artifactId>
@@ -117,6 +117,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-common</artifactId>
+    <version>4.1.116.Final</version>
+</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+      <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <dependency>
-    <groupId>io.netty</groupId>
-    <artifactId>netty-common</artifactId>
-    <version>4.1.116.Final</version>
-</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>


### PR DESCRIPTION
The 'dependency-check' target uses a variable
dependency_check_suppressions_repo_branch
which previously pointed to a different branch:
feature/suppressions-for-company-accounts-api
... but that branch has been merged into main and so this variable should now point to main.