### PR TITLE
 Fix for CVE-2024-31141

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Temporarily pinned netty dependency see Jira SEC-160 -->
+            <dependency>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-common</artifactId>
+              <version>4.1.116.Final</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>


### PR DESCRIPTION
Fixes CVE-2024-31141 by temporarily pinning netty-common