### PR TITLE
ASM-239: Remove `efs-sbumission-api` security vulnerabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ version             := unversioned
 
 dependency_check_base_suppressions:=common_suppressions_spring_6.xml
 dependency_check_suppressions_repo_branch:=main
-dependency_check_minimum_cvss := 10
+dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
 suppressions_file := target/suppressions.xml

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,7 @@
         <!-- Maven -->
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-failsafe-plugin.version>3.5.0</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
 
@@ -57,7 +56,7 @@
         <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <snappy-java.version>1.1.10.5</snappy-java.version>
-        <spring-boot.version>3.3.5</spring-boot.version>
+        <spring-boot.version>3.4.5</spring-boot.version>
         <spring-test.version>6.1.14</spring-test.version>
         <structured-logging.version>3.0.20</structured-logging.version>
         <sqs-common-version>0.0.1</sqs-common-version>
@@ -223,7 +222,7 @@
             <version>${sonar-maven-plugin.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
+                    <groupId>org.sonatype.plexus</groupId>
                     <artifactId>plexus-sec-dispatcher</artifactId>
                 </exclusion>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,6 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- Temporarily pinned netty dependency see Jira SEC-160 -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>4.1.118.Final</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Spring Actuator
-management.endpoints.enabled-by-default=${MANAGEMENT_ENDPOINTS_ENABLED_BY_DEFAULT}
+management.endpoints.enabled=${MANAGEMENT_ENDPOINTS_ENABLED_BY_DEFAULT}
 management.endpoint.health.enabled=${MANAGEMENT_ENDPOINT_HEALTH_ENABLED}
 management.endpoints.web.path-mapping.health=${MANAGEMENT_ENDPOINTS_WEB_PATH_MAPPING_HEALTH}
 management.endpoints.web.base-path=${MANAGEMENT_ENDPOINTS_WEB_BASE_PATH}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,9 @@
 # Spring Actuator
 management.endpoints.enabled=${MANAGEMENT_ENDPOINTS_ENABLED_BY_DEFAULT}
 management.endpoint.health.enabled=${MANAGEMENT_ENDPOINT_HEALTH_ENABLED}
+management.endpoint.maintenance.enabled=${MANAGEMENT_ENDPOINT_MAINTENANCE_ENABLED}
 management.endpoints.web.path-mapping.health=${MANAGEMENT_ENDPOINTS_WEB_PATH_MAPPING_HEALTH}
+management.endpoints.web.path-mapping.maintenance=${MANAGEMENT_ENDPOINTS_WEB_PATH_MAPPING_MAINTENANCE}
 management.endpoints.web.base-path=${MANAGEMENT_ENDPOINTS_WEB_BASE_PATH}
 management.endpoints.web.exposure.include=health,info,maintenance
 


### PR DESCRIPTION
Part of [ASM-239](https://companieshouse.atlassian.net/jira/software/c/projects/ASM/boards/585?selectedIssue=ASM-239). The maintenance work for `efs-submission-api` the `dependency_check_minimum_cvss` (Common Vulnerability Scoring System) was set to 4 and changes were implemented to successfully build this module:

Updates to POM dependencies included:
- general tidy up e.g. update `groupId` in the exclusion for `plexus-sec-dispatcher`
- replacement of `maven.compiler.source` and `maven.compiler.target` with `maven.compiler.release` - to rectify build warning
- upgrade to `spring-boot.version` 3.4.5 to ensure a successful dependency check

As a result of the Spring Boot increment, some `management.enpoints.x` properties were updated/added to ensure the planned maintenance endpoint remained accessible.

This will also resolve [ASM-517](https://companieshouse.atlassian.net/jira/software/c/projects/ASM/boards/585?selectedIssue=ASM-517)

Note to run the `efs-submission-api` in Docker, I needed to:

1. run the `efs` module without dev mode enabled
2. delete the main branch Docker image
3. generate an image with current changes using:
`mvn compile -s settings.xml jib:dockerBuild -Dimage=416670754337.dkr.ecr.eu-west-2.amazonaws.com/efs-submission-api`


[ASM-239]: https://companieshouse.atlassian.net/browse/ASM-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ASM-517]: https://companieshouse.atlassian.net/browse/ASM-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ