### PR TITLE
Fix dev enablement in Docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <snappy-java.version>1.1.10.5</snappy-java.version>
         <spring-boot.version>3.4.5</spring-boot.version>
+        <spring-data-mongodb.version>4.4.5</spring-data-mongodb.version>
         <spring-test.version>6.1.14</spring-test.version>
         <structured-logging.version>3.0.20</structured-logging.version>
         <sqs-common-version>0.0.1</sqs-common-version>
@@ -409,6 +410,11 @@
             <artifactId>aws-java-sdk-core</artifactId>
             <version>${aws-java-sdk-core.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+            <version>${spring-data-mongodb.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
**Jira ticket**: ASM-564

## Brief description of the change(s)
The development image could not be built using `cdev development enable efs-submission-api`. 
with error in `docker-chs-development-efs-submission-api-builder` logs:
`[ERROR] /app/src/main/java/uk/gov/companieshouse/efs/api/submissions/model/Company.java:[14,12] invalid method declaration; return type required`

Compilation error was fixed by adding a dependency to `pom.xml` for `spring-data-mongodb`

## Working example
```
[INFO] --- spring-boot-maven-plugin:3.4.5:repackage (default) @ efs-submission-api ---

[INFO] Replacing main artifact /app/target/efs-submission-api-unversioned.jar with repackaged archive, adding nested dependencies in BOOT-INF/.

[INFO] The original artifact has been renamed to /app/target/efs-submission-api-unversioned.jar.original

[INFO] ------------------------------------------------------------------------

[INFO] BUILD SUCCESS
```


## Test notes
Regression test of the efs module.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
~~- [ ] Added/updated logging appropriately.~~
~~- [ ] Written tests.~~
- [x] Tested the new code in my local environment.
~~- [ ] Updated Docker/ECS configs.~~
~~- [ ] Added all new properties to chs-configs.~~
~~- [ ] Updated release notes.~~

Strikethrough (`~~like this~~`) anything not applicable to your changes.
