### PR TITLE
update to spring-boot 3.5.11, remove commons-lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
         <skip.unit.tests>false</skip.unit.tests>
         <java.version>21</java.version>
         <api-helper-java.version>3.0.3</api-helper-java.version>
-        <avro.version>1.12.0</avro.version>
+        <avro.version>1.12.1</avro.version>
         <aws-java-sdk-core.version>1.12.787</aws-java-sdk-core.version>
         <software.amazon.awssdk.version>2.35.1</software.amazon.awssdk.version>
-        <ch-kafka.version>3.0.2</ch-kafka.version>
+        <ch-kafka.version>3.0.7</ch-kafka.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <commons-io.version>2.19.0</commons-io.version>
         <commons-lang3.version>3.19.0</commons-lang3.version>
@@ -52,12 +52,13 @@
 
         <mockito-junit-jupiter.version>5.2.0</mockito-junit-jupiter.version>
         <mockserver-client-java.version>5.15.0</mockserver-client-java.version>
+        <bcprov-jdk180n.version>1.83</bcprov-jdk180n.version>
         <nimbus-jose-jwt.version>10.3</nimbus-jose-jwt.version>
         <private-api-sdk-java.version>4.0.454</private-api-sdk-java.version>
         <sdk-manager-java.version>3.0.14</sdk-manager-java.version>
         <snakeyaml.version>2.4</snakeyaml.version>
         <snappy-java.version>1.1.10.7</snappy-java.version>
-        <spring-boot.version>3.5.10</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
         <spring-test.version>6.2.8</spring-test.version>
         <structured-logging.version>3.0.50</structured-logging.version>
         <sqs-common-version>0.0.1</sqs-common-version>
@@ -234,6 +235,10 @@
                     <groupId>org.sonarsource.scanner.api</groupId>
                     <artifactId>sonar-scanner-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -401,6 +406,14 @@
             <artifactId>oracle-xe</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
+        </dependency>
+        <!-- update from version 1.72 with 7 vulnerabilities,
+        in transitive dependency of mockserver-client-java 5.15.0 -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bcprov-jdk180n.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>

--- a/src/main/java/uk/gov/companieshouse/efs/api/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/interceptor/AuthenticationHelperImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.efs.api.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Helper class for user authentication.

--- a/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/paymentreports/service/PaymentReportServiceImpl.java
@@ -24,7 +24,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -108,7 +108,7 @@ public class PaymentReportServiceImpl implements PaymentReportService {
     public void sendFinancePaymentReports() throws IOException {
         List<PaymentTransaction> sh19Transactions =
             findPaymentTransactions(SUCCESSFUL_STATUSES).stream()
-                .filter(p -> StringUtils.startsWith(p.getFormType(), "SH19"))
+                .filter(p -> (p.getFormType().startsWith("SH19")))
                 .toList();
         createReport(sh19FinanceReportPattern, sh19Transactions);
         createReport(failedTransactionsFinanceReportPattern, findPaymentTransactions(FAILED_STATUSES));

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/PaymentSessionsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/validator/PaymentSessionsValidator.java
@@ -4,7 +4,8 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Optional;
-import org.apache.commons.lang.StringUtils;
+
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 import uk.gov.companieshouse.efs.api.formtemplates.repository.FormTemplateRepository;

--- a/src/main/java/uk/gov/companieshouse/efs/api/util/RandomStringPattern.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/util/RandomStringPattern.java
@@ -3,7 +3,8 @@ package uk.gov.companieshouse.efs.api.util;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Random;
-import org.apache.commons.lang.StringUtils;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Class to generate different types of random strings using a template pattern.

--- a/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/PaymentReportEmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/email/mapper/PaymentReportEmailMapperTest.java
@@ -8,7 +8,8 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.time.Month;
-import org.apache.commons.lang.StringUtils;
+import java.util.Objects;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -62,9 +63,9 @@ class PaymentReportEmailMapperTest {
         when(config.getAppId()).thenReturn("efs-submission-api.payment_report");
         when(config.getMessageType()).thenReturn("efs_payment_report");
         when(config.getDateFormat()).thenReturn("dd MMMM yyyy");
-        if (StringUtils.equals("scottish", reportType)) {
+        if (Objects.equals("scottish", reportType)) {
             when(config.getScottishEmailAddress()).thenReturn("scot_internal_demo@ch.gov.uk");
-        } else if (StringUtils.equals("specCap", reportType)) {
+        } else if (Objects.equals("specCap", reportType)) {
             when(config.getSpecialCapitalEmailAddress()).thenReturn("specCap_internal_demo@ch.gov.uk");
         }
         when(config.getFinanceEmailAddress()).thenReturn("internal_demo@ch.gov.uk");
@@ -72,9 +73,9 @@ class PaymentReportEmailMapperTest {
         when(timestampGenerator.generateTimestamp()).thenReturn(createAtLocalDateTime);
 
         when(model.getFileLink()).thenReturn("file-link");
-        if (StringUtils.equals("scottish", reportType)) {
+        if (Objects.equals("scottish", reportType)) {
             when(model.getFileName()).thenReturn("file-nameScottish");
-        } else if (StringUtils.equals("specCap", reportType)) {
+        } else if (Objects.equals("specCap", reportType)) {
             when(model.getFileName()).thenReturn("file-nameSH19");
         } else {
             when(model.getFileName()).thenReturn("file-name");
@@ -83,9 +84,9 @@ class PaymentReportEmailMapperTest {
 
     private EmailDocument<PaymentReportEmailData> expectedPaymentReportEmailDocument(final String reportType) {
         final String fileName;
-        if (StringUtils.equals("scottish", reportType)) {
+        if (Objects.equals("scottish", reportType)) {
             fileName = "file-nameScottish";
-        } else if (StringUtils.equals("specCap", reportType)) {
+        } else if (Objects.equals("specCap", reportType)) {
             fileName = "file-nameSH19";
         } else {
             fileName = "file-name";
@@ -100,9 +101,9 @@ class PaymentReportEmailMapperTest {
     }
 
     private String getReportEmailAddress(final String reportType) {
-        if (StringUtils.equals("scottish", reportType)) {
+        if (Objects.equals("scottish", reportType)) {
             return ("scot_internal_demo@ch.gov.uk");
-        } else if (StringUtils.equals("specCap", reportType)) {
+        } else if (Objects.equals("specCap", reportType)) {
             return ("specCap_internal_demo@ch.gov.uk");
         } else {
             return ("internal_demo@ch.gov.uk");


### PR DESCRIPTION
**Jira ticket**: ASM-1504

## Brief description of the change(s)
- spring-boot-dependencies 3.5.10 to 3.5.11
- remove commons-lang
  - exclude from sonar-maven-plugin
  - replace imports with `commons-lang3`

## Working example
<img width="1087" height="915" alt="Screenshot 2026-02-20 at 10 38 50 am" src="https://github.com/user-attachments/assets/01e0c5a8-f4a9-4939-a09e-b7266742cac6" />

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [x] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
