### PR TITLE
Fix for multiple files submission bypass

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/FileController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/FileController.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.efs.api.submissions.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
@@ -12,8 +13,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionFormApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionResponseApi;
+import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.efs.api.submissions.service.SubmissionService;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionIncorrectStateException;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionNotFoundException;
@@ -25,12 +30,17 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 public class FileController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("efs-submission-api");
+    private static final int FES_ENABLED_FORM_MAX_FILES = 1;
+    private static final int NON_FES_ENABLED_MAX_FILES = 10;
 
-    private SubmissionService service;
+    private final SubmissionService submissionService;
+    private final FormTemplateService formTemplateService;
 
 
-    public FileController(SubmissionService service) {
-        this.service = service;
+    public FileController(final SubmissionService submissionService,
+        final FormTemplateService formTemplateService) {
+        this.submissionService = submissionService;
+        this.formTemplateService = formTemplateService;
     }
 
     /**
@@ -52,14 +62,33 @@ public class FileController {
 
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
+        if (maxFileCountExceeded(id, files)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
 
         try {
-            return ResponseEntity.ok(service.updateSubmissionWithFileDetails(id, files));
+            return ResponseEntity.ok(submissionService.updateSubmissionWithFileDetails(id, files));
         } catch (SubmissionNotFoundException ex) {
             return ResponseEntity.notFound().build();
         } catch (SubmissionIncorrectStateException ex) {
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         }
 
+    }
+
+    private boolean maxFileCountExceeded(final String id, final @NotNull FileListApi files) {
+        final var filesCount = files.getFiles().size();
+        final var maxFiles = Optional.ofNullable(submissionService.readSubmission(id))
+            .map(SubmissionApi::getSubmissionForm)
+            .map(SubmissionFormApi::getFormType)
+            .map(formTemplateService::getFormTemplate)
+            .filter(FormTemplateApi::isFesEnabled)
+            .map(template -> FES_ENABLED_FORM_MAX_FILES)
+            .orElse(NON_FES_ENABLED_MAX_FILES);
+        if (filesCount > maxFiles) {
+            LOGGER.info("File list details are invalid: maximum file count %d exceeded for submission with id: [%s]".formatted(maxFiles, id));
+            return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/controller/FileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/controller/FileControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import jakarta.validation.Validation;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,9 +20,13 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
+import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionFormApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionResponseApi;
+import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.efs.api.submissions.service.SubmissionService;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionIncorrectStateException;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionNotFoundException;
@@ -31,16 +36,20 @@ class FileControllerTest {
 
     private static final String SUBMISSION_ID = "SUB-001";
     private static final String ENDPOINT = "/efs-submission-api/submission/{id}/files";
+    private static final String FORM_TYPE = "CC01";
 
     @Mock
     private SubmissionService submissionService;
+
+    @Mock
+    private FormTemplateService formTemplateService;
 
     private MockMvc mockMvc;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        final var fileController = new FileController(submissionService);
+        final var fileController = new FileController(submissionService, formTemplateService);
         final SpringValidatorAdapter validator;
         try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
             validator = new SpringValidatorAdapter(validatorFactory.getValidator());
@@ -54,6 +63,10 @@ class FileControllerTest {
     @Test
     void shouldAcceptValidFilenamesAndReturnOk() throws Exception {
         final var expectedResponse = new SubmissionResponseApi(SUBMISSION_ID);
+        final var submissionApi = createSubmissionWithFormType(FORM_TYPE);
+        final var formTemplate = createFormTemplate(false);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplate);
         when(submissionService.updateSubmissionWithFileDetails(any(), any()))
             .thenReturn(expectedResponse);
 
@@ -111,6 +124,10 @@ class FileControllerTest {
 
     @Test
     void shouldReturnNotFoundWhenSubmissionDoesNotExist() throws Exception {
+        final var submissionApi = createSubmissionWithFormType(FORM_TYPE);
+        final var formTemplate = createFormTemplate(false);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplate);
         final var fileList = new FileListApi(List.of(
             new FileApi("file-1", "document.pdf", 1024L)
         ));
@@ -126,6 +143,10 @@ class FileControllerTest {
 
     @Test
     void shouldReturnConflictWhenSubmissionIsInIncorrectState() throws Exception {
+        final var submissionApi = createSubmissionWithFormType(FORM_TYPE);
+        final var formTemplate = createFormTemplate(false);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplate);
         final var fileList = new FileListApi(List.of(
             new FileApi("file-1", "document.pdf", 1024L)
         ));
@@ -137,5 +158,115 @@ class FileControllerTest {
                 .content(objectMapper.writeValueAsString(fileList)))
             .andExpect(status().isConflict())
             .andExpect(content().string(""));
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenFesEnabledFormExceedsMaxOneFile() throws Exception {
+        final var submissionApi = createSubmissionWithFormType(FORM_TYPE);
+        final var formTemplate = createFormTemplate(true);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplate);
+
+        final var fileList = new FileListApi(List.of(
+            new FileApi("file-1", "document1.pdf", 1024L),
+            new FileApi("file-2", "document2.pdf", 2048L)
+        ));
+
+        mockMvc.perform(put(ENDPOINT, SUBMISSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(fileList)))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(""));
+    }
+
+    @Test
+    void shouldReturnOkWhenFesEnabledFormHasExactlyOneFile() throws Exception {
+        final var expectedResponse = new SubmissionResponseApi(SUBMISSION_ID);
+        final var submissionApi = createSubmissionWithFormType(FORM_TYPE);
+        final var formTemplate = createFormTemplate(true);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplate);
+        when(submissionService.updateSubmissionWithFileDetails(any(), any()))
+            .thenReturn(expectedResponse);
+
+        final var fileList = new FileListApi(List.of(
+            new FileApi("file-1", "document.pdf", 1024L)
+        ));
+
+        mockMvc.perform(put(ENDPOINT, SUBMISSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(fileList)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenNonFesFormExceedsMaxTenFiles() throws Exception {
+        final var submissionApi = createSubmissionWithFormType(FORM_TYPE);
+        final var formTemplate = createFormTemplate(false);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplate);
+
+        final var files = IntStream.rangeClosed(1, 11)
+            .mapToObj(i -> new FileApi("file-" + i, "document" + i + ".pdf", 1024L))
+            .toList();
+        final var fileList = new FileListApi(files);
+
+        mockMvc.perform(put(ENDPOINT, SUBMISSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(fileList)))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(""));
+    }
+
+    @Test
+    void shouldReturnOkWhenNonFesFormHasExactlyTenFiles() throws Exception {
+        final var expectedResponse = new SubmissionResponseApi(SUBMISSION_ID);
+        final var submissionApi = createSubmissionWithFormType(FORM_TYPE);
+        final var formTemplate = createFormTemplate(false);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplate);
+        when(submissionService.updateSubmissionWithFileDetails(any(), any()))
+            .thenReturn(expectedResponse);
+
+        final var files = IntStream.rangeClosed(1, 10)
+            .mapToObj(i -> new FileApi("file-" + i, "document" + i + ".pdf", 1024L))
+            .toList();
+        final var fileList = new FileListApi(files);
+
+        mockMvc.perform(put(ENDPOINT, SUBMISSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(fileList)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenSubmissionHasNoFormDetails() throws Exception {
+        final var submissionApi = new SubmissionApi(SUBMISSION_ID, null, null, null, null, null,
+            null, null, null, null, null, null, null);
+        when(submissionService.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+
+        final var files = IntStream.rangeClosed(1, 11)
+            .mapToObj(i -> new FileApi("file-" + i, "document" + i + ".pdf", 1024L))
+            .toList();
+        final var fileList = new FileListApi(files);
+
+        mockMvc.perform(put(ENDPOINT, SUBMISSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(fileList)))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(""));
+    }
+
+    private SubmissionApi createSubmissionWithFormType(final String formType) {
+        final var submissionForm = new SubmissionFormApi();
+        submissionForm.setFormType(formType);
+        return new SubmissionApi(SUBMISSION_ID, null, null, null, null, null, null, null,
+            submissionForm, null, null, null, null);
+    }
+
+    private FormTemplateApi createFormTemplate(final boolean fesEnabled) {
+        final var formTemplate = new FormTemplateApi();
+        formTemplate.setFesEnabled(fesEnabled);
+        return formTemplate;
     }
 }


### PR DESCRIPTION
## Brief description of the change(s)
Fix security bypass for multiple file details



## Jira ticket

https://companieshouse.atlassian.net/browse/ASM-2564

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.



## Checklist
>
> Paste the ⭕️ emoji into the respective columns below. If a checklist item *is* applicable but you haven't done it, omit the emoji from both columns. You can optionally add notes to clear up ambiguity. Whitespace isn't important, as long as the emoji is within the cell `|  |` it will render correctly.

| Item                                                       | Done | Not applicable | Notes |
|:-----------------------------------------------------------|:----:|:--------------:|-------|
| Adhered to the CH style guide (required)                   |  ⭕️  |                |       |
| Added/updated logging                                      |  ⭕   |                |       |
| Written tests                                              |  ⭕   |                |       |
| Tested the new code in my local environment                |  ⭕   |                |       |
| Updated Docker/ECS configs                                 |      |       ⭕        |       |
| Updated release ticket description with any config changes |      |                |       |
| Updated release ticket to link to this work item           |      |                |       |
