### PR TITLE
Refactor efs-submission-api file transfer config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <junit-jupiter.version>5.13.1</junit-jupiter.version>
         <kafka-clients.version>4.0.2</kafka-clients.version>
         <kafka-models.version>3.0.18</kafka-models.version>
-        <log4j-bom.version>2.25.4</log4j-bom.version>
+        <log4j-bom.version>2.26.1</log4j-bom.version>
         <ojdbc11.version>23.8.0.25.04</ojdbc11.version>
         <tomcat.version>11.0.24</tomcat.version>
         <!-- Maven -->

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngine.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngine.java
@@ -9,7 +9,7 @@ import uk.gov.companieshouse.api.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileConversionStatus;
 import uk.gov.companieshouse.efs.api.events.service.model.Decision;
 import uk.gov.companieshouse.efs.api.events.service.model.DecisionResult;
-import uk.gov.companieshouse.efs.api.filetransfer.FileTransferService;
+import uk.gov.companieshouse.efs.api.filetransfer.FileTransferServiceClient;
 import uk.gov.companieshouse.efs.api.formtemplates.repository.FormTemplateRepository;
 import uk.gov.companieshouse.efs.api.submissions.model.FileDetails;
 import uk.gov.companieshouse.efs.api.submissions.model.Submission;
@@ -25,14 +25,14 @@ public class DecisionEngine {
     private static final String AV_CLEAN = "clean";
     private static final Logger LOGGER = LoggerFactory.getLogger("efs-submission-api");
 
-    private final FileTransferService fileTransferService;
+    private final FileTransferServiceClient fileTransferServiceClient;
     private final FormTemplateRepository repository;
     private final CurrentTimestampGenerator timestampGenerator;
     private final SubmissionService submissionService;
 
-    public DecisionEngine(final FileTransferService fileTransferService, final FormTemplateRepository repository,
+    public DecisionEngine(final FileTransferServiceClient fileTransferServiceClient, final FormTemplateRepository repository,
                           final CurrentTimestampGenerator timestampGenerator, final SubmissionService submissionService) {
-        this.fileTransferService = fileTransferService;
+        this.fileTransferServiceClient = fileTransferServiceClient;
         this.repository = repository;
         this.timestampGenerator = timestampGenerator;
         this.submissionService = submissionService;
@@ -61,7 +61,7 @@ public class DecisionEngine {
 
     private void checkAvStatus(final String submissionId, final Decision decision, final FileDetails fileDetails) {
         LOGGER.debug("Checking AV status for file with id [%s] in submission [%s]".formatted(fileDetails.getFileId(), submissionId));
-        fileTransferService.getFileDetails(fileDetails.getFileId())
+        fileTransferServiceClient.getFileDetails(fileDetails.getFileId())
             .map(FileDetailsApi::getAvStatus)
             .map(AvStatus::getValue)
             .ifPresent(avStatus -> handleAvStatus(avStatus, decision, fileDetails));

--- a/src/main/java/uk/gov/companieshouse/efs/api/filetransfer/FileTransferServiceClient.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/filetransfer/FileTransferServiceClient.java
@@ -12,15 +12,15 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
 
 @Service
-public class FileTransferService {
+public class FileTransferServiceClient {
 
-    @Value( "${file.transfer.api.url}" )
-    private String fileTransferApiUrl;
+    @Value( "${file.transfer.service.url}" )
+    private String fileTransferServiceUrl;
     private final ApiClientUtil apiClientUtil;
 
     private final Logger logger;
 
-    public FileTransferService(final ApiClientUtil apiClientUtil, final Logger logger) {
+    public FileTransferServiceClient(final ApiClientUtil apiClientUtil, final Logger logger) {
         this.apiClientUtil = apiClientUtil;
         this.logger = logger;
     }
@@ -45,7 +45,7 @@ public class FileTransferService {
     }
 
     public ApiResponse<FileDetailsApi> details( final String fileId ) throws ApiErrorResponseException, URIValidationException {
-        return apiClientUtil.getInternalFileTransferClient(fileTransferApiUrl)
+        return apiClientUtil.getInternalFileTransferClient(fileTransferServiceUrl)
                 .privateFileTransferHandler()
                 .details( fileId )
                 .execute();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,8 +33,7 @@ submission.processing.support.hours=${EFS_SUBMISSION_PROCESSING_SUPPORT_HOURS}
 submission.processing.business.hours=${EFS_SUBMISSION_PROCESSING_BUSINESS_HOURS}
 submission.sameday.support.minutes=${EFS_SUBMISSION_PROCESSING_SAMEDAY_SUPPORT_MINUTES}
 
-file.transfer.api.key=${FILE_TRANSFER_API_KEY}
-file.transfer.api.url=${FILE_TRANSFER_API_URL}
+file.transfer.service.url=${FILE_TRANSFER_SERVICE_URL}
 
 chs.internal.api.key=${CHS_INTERNAL_API_KEY}
 

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/DecisionEngineTest.java
@@ -22,7 +22,7 @@ import uk.gov.companieshouse.api.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileConversionStatus;
 import uk.gov.companieshouse.efs.api.events.service.model.DecisionResult;
 import uk.gov.companieshouse.efs.api.filetransfer.FileDetailsException;
-import uk.gov.companieshouse.efs.api.filetransfer.FileTransferService;
+import uk.gov.companieshouse.efs.api.filetransfer.FileTransferServiceClient;
 import uk.gov.companieshouse.efs.api.formtemplates.model.FormTemplate;
 import uk.gov.companieshouse.efs.api.formtemplates.repository.FormTemplateRepository;
 import uk.gov.companieshouse.efs.api.submissions.model.FileDetails;
@@ -44,7 +44,7 @@ class DecisionEngineTest {
     private DecisionEngine decisionEngine;
 
     @Mock
-    private FileTransferService transferService;
+    private FileTransferServiceClient transferService;
 
     @Mock
     private Submission submission;

--- a/src/test/java/uk/gov/companieshouse/efs/api/filetransfer/FileTransferServiceClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/filetransfer/FileTransferServiceClientTest.java
@@ -28,12 +28,12 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
 
 @ExtendWith(MockitoExtension.class)
-class FileTransferServiceTest {
+class FileTransferServiceClientTest {
 
     private static final String FILE_TRANSFER_URL = "http://file-transfer-api";
     private static final String FILE_ID = "file-id-123";
 
-    private FileTransferService fileTransferService;
+    private FileTransferServiceClient fileTransferServiceClient;
 
     @Mock
     private ApiClientUtil apiClientUtil;
@@ -52,8 +52,8 @@ class FileTransferServiceTest {
 
     @BeforeEach
     void setUp() {
-        fileTransferService = new FileTransferService(apiClientUtil, logger);
-        ReflectionTestUtils.setField(fileTransferService, "fileTransferApiUrl", FILE_TRANSFER_URL);
+        fileTransferServiceClient = new FileTransferServiceClient(apiClientUtil, logger);
+        ReflectionTestUtils.setField(fileTransferServiceClient, "fileTransferServiceUrl", FILE_TRANSFER_URL);
 
         when(apiClientUtil.getInternalFileTransferClient(FILE_TRANSFER_URL)).thenReturn(internalFileTransferClient);
     }
@@ -62,7 +62,7 @@ class FileTransferServiceTest {
     void detailsReturnsApiResponse() throws Exception {
         when(internalFileTransferClient.privateFileTransferHandler().details(FILE_ID).execute()).thenReturn(apiResponse);
 
-        final var response = fileTransferService.details(FILE_ID);
+        final var response = fileTransferServiceClient.details(FILE_ID);
 
         assertThat(response, sameInstance(apiResponse));
         verify(apiClientUtil).getInternalFileTransferClient(FILE_TRANSFER_URL);
@@ -73,7 +73,7 @@ class FileTransferServiceTest {
         when(internalFileTransferClient.privateFileTransferHandler().details(FILE_ID).execute()).thenReturn(apiResponse);
         when(apiResponse.getData()).thenReturn(fileDetailsApi);
 
-        final var result = fileTransferService.getFileDetails(FILE_ID);
+        final var result = fileTransferServiceClient.getFileDetails(FILE_ID);
 
         assertThat(result.isPresent(), is(true));
         assertThat(result.get(), sameInstance(fileDetailsApi));
@@ -84,7 +84,7 @@ class FileTransferServiceTest {
         when(internalFileTransferClient.privateFileTransferHandler().details(FILE_ID).execute()).thenReturn(apiResponse);
         when(apiResponse.getData()).thenReturn(null);
 
-        final var result = fileTransferService.getFileDetails(FILE_ID);
+        final var result = fileTransferServiceClient.getFileDetails(FILE_ID);
 
         assertThat(result.isEmpty(), is(true));
     }
@@ -95,7 +95,7 @@ class FileTransferServiceTest {
         when(apiError.getStatusCode()).thenReturn(404);
         when(internalFileTransferClient.privateFileTransferHandler().details(FILE_ID).execute()).thenThrow(apiError);
 
-        final var result = fileTransferService.getFileDetails(FILE_ID);
+        final var result = fileTransferServiceClient.getFileDetails(FILE_ID);
 
         assertThat(result.isEmpty(), is(true));
         verify(logger, never()).errorContext(anyString(), anyString(), isNull(), anyMap());
@@ -109,7 +109,7 @@ class FileTransferServiceTest {
             .thenThrow(uriValidationException);
 
         final var thrown = assertThrows(FileDetailsException.class,
-            () -> fileTransferService.getFileDetails(FILE_ID));
+            () -> fileTransferServiceClient.getFileDetails(FILE_ID));
 
         assertThat(thrown.getMessage(), is("invalid URI"));
     }
@@ -122,7 +122,7 @@ class FileTransferServiceTest {
         when(internalFileTransferClient.privateFileTransferHandler().details(FILE_ID).execute()).thenThrow(apiError);
 
         final var thrown = assertThrows(FileDetailsException.class,
-            () -> fileTransferService.getFileDetails(FILE_ID));
+            () -> fileTransferServiceClient.getFileDetails(FILE_ID));
 
         assertThat(thrown.getMessage(), is("server error"));
         verify(logger).errorContext(

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,7 +1,6 @@
 max.queue.messages=50
 file.bucket.name=test-bucket
 tiff.bucket.name=test-bucket
-file.transfer.api.key=1234
 message.partition.size=1
 internal.constitution.email.address=demo@companieshouse.gov.uk
 internal.regfunc.email.address=demo@companieshouse.gov.uk


### PR DESCRIPTION

## Brief description of the change(s)

- Remove references to file.transfer.api.key.
- Rename file.transfer.api.url to file.transfer.service.url.
- Rename FileTransferService to FileTransferServiceClient.

https://companieshouse.atlassian.net/browse/ASM-2647

## Test notes

- End to end regression test required.

## Checklist
>
> Paste the ⭕️ emoji into the respective columns below. If a checklist item *is* applicable but you haven't done it, omit the emoji from both columns. You can optionally add notes to clear up ambiguity. Whitespace isn't important, as long as the emoji is within the cell `|  |` it will render correctly.

| Item                                                       | Done | Not applicable | Notes |
|:-----------------------------------------------------------|:----:|:--------------:|-------|
| Adhered to the CH style guide (required)                   |  ⭕️  |                |       |
| Added/updated logging                                      |      |        ⭕️        |       |
| Written tests                                              |   ⭕️   |                |       |
| Tested the new code in my local environment                |   ⭕️   |                |       |
| Updated Docker/ECS configs                                 |    ⭕️  |                 |       |
| Updated release ticket description with any config changes |      |        ⭕️         |       |
| Updated release ticket to link to this work item           |      |        ⭕️         |       |
