### PR TITLE
feature/ASM-2728-fix-document-upload-remove-fails-after-form-type-changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <commons-io.version>2.19.0</commons-io.version>
         <environment-reader-library.version>3.0.1</environment-reader-library.version>
         <equalsverifier.version>4.0.2</equalsverifier.version>
+        <awaitility.version>4.3.0</awaitility.version>
         <google-oauth-client.version>1.39.0</google-oauth-client.version>
         <guava.version>33.4.8-jre</guava.version>
         <imageio.version>1.4.0</imageio.version>
@@ -390,6 +391,10 @@
                     <groupId>org.eclipse.jetty.ee10</groupId>
                     <artifactId>jetty-ee10-webapp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -435,11 +440,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -450,6 +467,12 @@
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <version>${equalsverifier.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/companieshouse/efs/api/config/SpringAsyncConfig.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/config/SpringAsyncConfig.java
@@ -1,0 +1,75 @@
+package uk.gov.companieshouse.efs.api.config;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Configures Spring async execution for fire-and-forget operations such as S3 file deletion.
+ *
+ * <p>Methods annotated with {@code @Async("threadPoolTaskExecutor")} will be dispatched
+ * to the thread pool defined here. Uncaught exceptions from async {@code void} methods
+ * are routed to {@link #getAsyncUncaughtExceptionHandler()} so they are logged rather
+ * than silently dropped by the framework.</p>
+ */
+@Configuration
+@EnableAsync
+public class SpringAsyncConfig implements AsyncConfigurer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("efs-submission-api");
+
+    @Value("${async.executor.core-pool-size}")
+    private int corePoolSize;
+
+    @Value("${async.executor.max-pool-size}")
+    private int maxPoolSize;
+
+    @Value("${async.executor.queue-capacity}")
+    private int queueCapacity;
+
+    /**
+     * Thread pool used for async task execution.
+     *
+     * <p>Pool sizes and queue capacity are configurable via {@code application.properties}</p>
+     * <p>Note: {@code @Bean} will manage bean initialization and invoke {@code executor.initialize()} automatically.</p>
+     *
+     * @return configured {@link ThreadPoolTaskExecutor}
+     */
+    @Bean(name = "threadPoolTaskExecutor")
+    @Override
+    public Executor getAsyncExecutor() {
+        final var executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("async-s3-");
+        return executor;
+    }
+
+    /**
+     * Logs uncaught exceptions thrown by async {@code void} methods.
+     *
+     * <p>Without this handler, exceptions from {@code @Async void} methods are silently
+     * swallowed by the framework. This ensures they appear in application logs.</p>
+     */
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (Throwable ex, Method method, Object... params) -> {
+            final Map<String, Object> logData = new HashMap<>();
+            logData.put("method", method.getName());
+            logData.put("error", ex.getClass().getName());
+            logData.put("message", ex.getMessage());
+            LOGGER.error("Uncaught exception in async method", logData);
+        };
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/config/SpringAsyncConfig.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/config/SpringAsyncConfig.java
@@ -43,6 +43,12 @@ public class SpringAsyncConfig implements AsyncConfigurer {
     @Value("${async.executor.allow-core-thread-timeout}")
     private boolean allowCoreThreadTimeOut;
 
+    @Value("${async.executor.wait-for-tasks-to-complete-on-shutdown}")
+    private boolean waitForTasksToCompleteOnShutdown;
+
+    @Value("${async.executor.await-termination-seconds}")
+    private int awaitTerminationSeconds;
+
     /**
      * Thread pool used for async task execution.
      *
@@ -62,6 +68,8 @@ public class SpringAsyncConfig implements AsyncConfigurer {
         executor.setThreadNamePrefix("async-s3-");
         executor.setKeepAliveSeconds(keepAliveSeconds);
         executor.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
+        executor.setWaitForTasksToCompleteOnShutdown(waitForTasksToCompleteOnShutdown);
+        executor.setAwaitTerminationSeconds(awaitTerminationSeconds);
 
         return executor;
     }

--- a/src/main/java/uk/gov/companieshouse/efs/api/config/SpringAsyncConfig.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/config/SpringAsyncConfig.java
@@ -37,10 +37,17 @@ public class SpringAsyncConfig implements AsyncConfigurer {
     @Value("${async.executor.queue-capacity}")
     private int queueCapacity;
 
+    @Value("${async.executor.keep-alive-seconds}")
+    private int keepAliveSeconds;
+
+    @Value("${async.executor.allow-core-thread-timeout}")
+    private boolean allowCoreThreadTimeOut;
+
     /**
      * Thread pool used for async task execution.
      *
-     * <p>Pool sizes and queue capacity are configurable via {@code application.properties}</p>
+     * <p>Pool sizes, queue capacity, and scale-down settings are configurable via
+     * {@code application.properties}</p>
      * <p>Note: {@code @Bean} will manage bean initialization and invoke {@code executor.initialize()} automatically.</p>
      *
      * @return configured {@link ThreadPoolTaskExecutor}
@@ -53,6 +60,9 @@ public class SpringAsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(maxPoolSize);
         executor.setQueueCapacity(queueCapacity);
         executor.setThreadNamePrefix("async-s3-");
+        executor.setKeepAliveSeconds(keepAliveSeconds);
+        executor.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
+
         return executor;
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteService.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+public interface S3FileDeleteService {
+    /**
+     * Deletes a file from S3 storage.
+     *
+     * @param submissionId the ID of the submission the file belongs to, used for logging context
+     * @param fileId  the S3 fileId of the file to delete
+     */
+    void deleteFile(final String submissionId, String fileId);
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteService.java
@@ -2,7 +2,10 @@ package uk.gov.companieshouse.efs.api.events.service;
 
 public interface S3FileDeleteService {
     /**
-     * Deletes a file from S3 storage.
+     * Asynchronously deletes a file from S3 storage.
+     *
+     * <p>Implementations must return immediately; the actual S3 request runs on
+     * a background thread. Delete failures should be logged without rethrowing.</p>
      *
      * @param submissionId the ID of the submission the file belongs to, used for logging context
      * @param fileId  the S3 fileId of the file to delete

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImpl.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Deletes uploaded submission files from the configured S3 file bucket.
+ *
+ * <p>Delete failures are logged with submission context and are not rethrown, so
+ * callers can continue processing other files.</p>
+ */
+@Component
+public class S3FileDeleteServiceImpl implements S3FileDeleteService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("efs-submission-api");
+
+    private final S3Client s3;
+    private final String bucketName;
+
+    /**
+     * Creates a delete service for the configured file upload bucket.
+     *
+     * @param s3 AWS S3 client used to issue delete requests
+     * @param bucketName bucket containing uploaded submission files
+     */
+    public S3FileDeleteServiceImpl(final S3Client s3, @Value("${file.bucket.name}") final String bucketName) {
+        this.s3 = s3;
+        this.bucketName = bucketName;
+    }
+
+    /**
+     * Deletes a single file object from S3 by file ID (object key).
+     *
+     * <p>If S3 deletion fails, the error is logged with the submission ID and file metadata,
+     * and processing continues without throwing.</p>
+     *
+     * @param submissionId submission identifier used for contextual logging
+     * @param fileId S3 object key for the uploaded file
+     */
+    @Override
+    public void deleteFile(final String submissionId, final String fileId) {
+        final var debugMap = buildLogMap(fileId);
+        LOGGER.debugContext(submissionId, "Deleting file from S3", debugMap);
+        try {
+            final var request = DeleteObjectRequest.builder()
+                                                   .bucket(bucketName)
+                                                   .key(fileId)
+                                                   .build();
+            s3.deleteObject(request);
+        } catch (SdkException ex) {
+            final var errorMap = buildLogMap(fileId);
+            LOGGER.errorContext(submissionId, "Unable to delete file from S3", ex, errorMap);
+        }
+    }
+
+    /**
+     * Builds structured log data for S3 delete operations.
+     *
+     * @param fileId S3 object key for the file being deleted
+     * @return log map containing file and bucket context
+     */
+    private @NonNull Map<String, Object> buildLogMap(final String fileId) {
+        final Map<String, Object> debug = new HashMap<>();
+        debug.put("fileId", fileId);
+        debug.put("bucketName", bucketName);
+        return debug;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImpl.java
@@ -59,7 +59,7 @@ public class S3FileDeleteServiceImpl implements S3FileDeleteService {
         try {
             final var request = DeleteObjectRequest.builder().bucket(bucketName).key(fileId).build();
             s3.deleteObject(request);
-            LOGGER.infoContext(submissionId, "Successfully deleted file from S3", buildLogMap(fileId));
+            LOGGER.debugContext(submissionId, "Successfully deleted file from S3", buildLogMap(fileId));
         } catch (SdkException ex) {
             LOGGER.errorContext(submissionId, "Unable to delete file from S3", ex, buildLogMap(fileId));
         }

--- a/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -14,8 +15,10 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 /**
  * Deletes uploaded submission files from the configured S3 file bucket.
  *
- * <p>Delete failures are logged with submission context and are not rethrown, so
- * callers can continue processing other files.</p>
+ * <p>Delete operations run asynchronously so callers return immediately without
+ * waiting for the S3 request to complete. Delete failures are logged with submission
+ * context and are not rethrown, so individual failures do not prevent remaining
+ * files from being deleted.</p>
  */
 @Component
 public class S3FileDeleteServiceImpl implements S3FileDeleteService {
@@ -37,27 +40,28 @@ public class S3FileDeleteServiceImpl implements S3FileDeleteService {
     }
 
     /**
-     * Deletes a single file object from S3 by file ID (object key).
+     * Asynchronously deletes a single file object from S3 by file ID (object key).
      *
-     * <p>If S3 deletion fails, the error is logged with the submission ID and file metadata,
-     * and processing continues without throwing.</p>
+     * <p>This method returns immediately; the S3 delete request is executed on a
+     * background thread. If S3 deletion fails, the error is logged with the submission
+     * ID and file metadata, and no exception is propagated to the caller.</p>
      *
      * @param submissionId submission identifier used for contextual logging
      * @param fileId S3 object key for the uploaded file
      */
+    @Async("threadPoolTaskExecutor")
     @Override
     public void deleteFile(final String submissionId, final String fileId) {
         final var debugMap = buildLogMap(fileId);
-        LOGGER.debugContext(submissionId, "Deleting file from S3", debugMap);
+        LOGGER.debugContext(submissionId,
+            "Deleting file from S3 using executor %s".formatted(Thread.currentThread().getName()),
+            debugMap);
         try {
-            final var request = DeleteObjectRequest.builder()
-                                                   .bucket(bucketName)
-                                                   .key(fileId)
-                                                   .build();
+            final var request = DeleteObjectRequest.builder().bucket(bucketName).key(fileId).build();
             s3.deleteObject(request);
+            LOGGER.infoContext(submissionId, "Successfully deleted file from S3", buildLogMap(fileId));
         } catch (SdkException ex) {
-            final var errorMap = buildLogMap(fileId);
-            LOGGER.errorContext(submissionId, "Unable to delete file from S3", ex, errorMap);
+            LOGGER.errorContext(submissionId, "Unable to delete file from S3", ex, buildLogMap(fileId));
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeController.java
@@ -57,10 +57,10 @@ public class ConfirmFormTypeController {
      * Confirms or updates the form type for a submission.
      *
      * <p>If the submission already has a form type and it differs from the requested
-     * form type, all existing uploaded files for that submission are deleted from S3 and the submission's stored file
-     * list is cleared before the form update.</p>
-     * <p>If any S3 delete fails, the error is logged and processing continues on to remove the submission's files list
-     * and update the submission's form type.</p>
+     * form type, all existing uploaded files are deleted from S3 asynchronously.
+     * Regardless of whether any S3 deletes fail (errors are logged), the submission's
+     * file list is cleared and the form type is updated. S3 failures never block the
+     * submission update.</p>
      *
      * @param id       submission id
      * @param formType requested form type payload
@@ -82,6 +82,7 @@ public class ConfirmFormTypeController {
 
         try {
             final var submission = service.readSubmission(id);
+
             if (isFormTypeChanged(submission, formType.getFormType())) {
                 LOGGER.info("Form type has changed, deleting %s files uploaded for submission with id: [%s]".formatted(
                     submission.getSubmissionForm().getFormType(),

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeController.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.efs.api.submissions.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
@@ -12,47 +13,82 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.efs.submissions.FileDetailApi;
+import uk.gov.companieshouse.api.model.efs.submissions.FileDetailListApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FormTypeApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionFormApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionResponseApi;
+import uk.gov.companieshouse.efs.api.events.service.S3FileDeleteService;
 import uk.gov.companieshouse.efs.api.submissions.service.SubmissionService;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionIncorrectStateException;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+/**
+ * Handles updates to a submission's form type.
+ *
+ * <p>When the incoming form type differs from the existing stored form type, any
+ * previously uploaded files are deleted from S3 and cleared from the submission
+ * before the form type update is applied.</p>
+ */
 @RestController
 @RequestMapping("/efs-submission-api/submission/{id}/form")
 public class ConfirmFormTypeController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("efs-submission-api");
 
-    private SubmissionService service;
+    private final SubmissionService service;
+    private final S3FileDeleteService s3FileDeleteService;
 
-    public ConfirmFormTypeController(SubmissionService service) {
+    /**
+     * Creates a controller for form type confirmation and related file cleanup.
+     *
+     * @param service submission service for read/update operations
+     * @param s3FileDeleteService S3 service used to delete uploaded submission files
+     */
+    public ConfirmFormTypeController(final SubmissionService service, final S3FileDeleteService s3FileDeleteService) {
         this.service = service;
+        this.s3FileDeleteService = s3FileDeleteService;
     }
 
     /**
-     * Endpoint for formType.
+     * Confirms or updates the form type for a submission.
      *
-     * @param id        submission id
-     * @param formType  form type
-     * @param result    bindingResult
-     * @return          ResponseEntity&lt;SubmissionResponseApi&gt;
+     * <p>If the submission already has a form type and it differs from the requested
+     * form type, all existing uploaded files for that submission are deleted from S3 and the submission's stored file
+     * list is cleared before the form update.</p>
+     * <p>If any S3 delete fails, the error is logged and processing continues on to remove the submission's files list
+     * and update the submission's form type.</p>
+     *
+     * @param id       submission id
+     * @param formType requested form type payload
+     * @param result   request validation result
+     * @return {@link ResponseEntity} containing {@link SubmissionResponseApi} on success, or an empty response with
+     *     HTTP 400/404/409 depending on failure mode
      */
     @PutMapping
-    public ResponseEntity<SubmissionResponseApi> confirmFormType(@PathVariable String id,
-            @RequestBody @Valid @NotNull FormTypeApi formType, BindingResult result) {
+    public ResponseEntity<SubmissionResponseApi> confirmFormType(@PathVariable final String id,
+            @RequestBody @Valid @NotNull final FormTypeApi formType, final BindingResult result) {
 
         if (result.hasErrors()) {
-            String message = Optional.ofNullable(result.getFieldError())
-                    .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                    .orElse(formType.getFormType());
+            final var message = Optional.ofNullable(result.getFieldError())
+                                        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                                        .orElse(formType.getFormType());
             LOGGER.info("Form type details are invalid: %s".formatted(message));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
 
         try {
+            final var submission = service.readSubmission(id);
+            if (isFormTypeChanged(submission, formType.getFormType())) {
+                LOGGER.info("Form type has changed, deleting %s files uploaded for submission with id: [%s]".formatted(
+                    submission.getSubmissionForm().getFormType(),
+                    id));
+                deleteSubmissionFiles(id, submission);
+                service.clearSubmissionFiles(id);
+            }
             return ResponseEntity.ok(service.updateSubmissionWithForm(id, formType));
         } catch (SubmissionNotFoundException ex) {
             return ResponseEntity.notFound().build();
@@ -61,4 +97,36 @@ public class ConfirmFormTypeController {
         }
     }
 
+    /**
+     * Checks whether the requested form type differs from the currently stored value.
+     *
+     * @param submission submission being updated
+     * @param requestedFormType requested form type value from the request payload
+     * @return {@code true} when an existing non-null form type differs from the request
+     */
+    private boolean isFormTypeChanged(final SubmissionApi submission, final String requestedFormType) {
+        return Optional.ofNullable(submission)
+            .map(SubmissionApi::getSubmissionForm)
+            .map(submissionForm -> submissionForm.getFormType() != null
+                && !submissionForm.getFormType().equals(requestedFormType))
+            .orElse(false);
+    }
+
+    /**
+     * Deletes all currently stored submission files from S3 using their file IDs.
+     *
+     * @param submissionId submission id used for contextual logging
+     * @param submission submission containing existing file metadata
+     */
+    private void deleteSubmissionFiles(final String submissionId, final SubmissionApi submission) {
+        final var fileDetails = Optional.ofNullable(submission)
+                                        .map(SubmissionApi::getSubmissionForm)
+                                        .map(SubmissionFormApi::getFileDetails)
+                                        .map(FileDetailListApi::getList)
+                                        .orElse(List.of());
+
+        fileDetails.stream()
+            .map(FileDetailApi::getFileId)
+            .forEach(fileId -> s3FileDeleteService.deleteFile(submissionId, fileId));
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeController.java
@@ -84,7 +84,8 @@ public class ConfirmFormTypeController {
             final var submission = service.readSubmission(id);
 
             if (isFormTypeChanged(submission, formType.getFormType())) {
-                LOGGER.info("Form type has changed, deleting %s files uploaded for submission with id: [%s]".formatted(
+                LOGGER.info("Form type will change to %s: deleting uploaded files for %s submission with id: [%s]".formatted(
+                    formType.getFormType(),
                     submission.getSubmissionForm().getFormType(),
                     id));
                 deleteSubmissionFiles(id, submission);

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionService.java
@@ -22,6 +22,8 @@ public interface SubmissionService {
 
     SubmissionResponseApi updateSubmissionWithForm(String id, FormTypeApi formApi);
 
+    SubmissionResponseApi clearSubmissionFiles(String id);
+
     SubmissionResponseApi updateSubmissionWithFileDetails(String id, FileListApi fileListApi);
 
     SubmissionResponseApi updateSubmissionWithPaymentSessions(String id, SessionListApi paymentSessions);

--- a/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImpl.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
 import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileConversionStatus;
 import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
@@ -23,13 +22,11 @@ import uk.gov.companieshouse.api.model.efs.submissions.PresenterApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionResponseApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionStatus;
-import uk.gov.companieshouse.api.model.paymentsession.SessionApi;
 import uk.gov.companieshouse.api.model.paymentsession.SessionListApi;
 import uk.gov.companieshouse.efs.api.email.EmailService;
 import uk.gov.companieshouse.efs.api.email.model.ExternalNotificationEmailModel;
 import uk.gov.companieshouse.efs.api.formtemplates.service.FormTemplateService;
 import uk.gov.companieshouse.efs.api.payment.PaymentClose;
-import uk.gov.companieshouse.efs.api.payment.entity.PaymentTemplate;
 import uk.gov.companieshouse.efs.api.payment.service.PaymentTemplateService;
 import uk.gov.companieshouse.efs.api.submissions.mapper.CompanyMapper;
 import uk.gov.companieshouse.efs.api.submissions.mapper.FileDetailsMapper;
@@ -37,7 +34,6 @@ import uk.gov.companieshouse.efs.api.submissions.mapper.PresenterMapper;
 import uk.gov.companieshouse.efs.api.submissions.mapper.SubmissionMapper;
 import uk.gov.companieshouse.efs.api.submissions.model.FileDetails;
 import uk.gov.companieshouse.efs.api.submissions.model.FormDetails;
-import uk.gov.companieshouse.efs.api.submissions.model.Presenter;
 import uk.gov.companieshouse.efs.api.submissions.model.Submission;
 import uk.gov.companieshouse.efs.api.submissions.repository.SubmissionRepository;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionIncorrectStateException;
@@ -63,17 +59,17 @@ public class SubmissionServiceImpl implements SubmissionService {
         Sets.immutableEnumSet(SubmissionStatus.OPEN, SubmissionStatus.PAYMENT_REQUIRED, SubmissionStatus.PAYMENT_FAILED,
             SubmissionStatus.SUBMITTED);
 
-    private SubmissionRepository submissionRepository;
-    private SubmissionMapper submissionMapper;
-    private PresenterMapper presenterMapper;
-    private CompanyMapper companyMapper;
-    private FileDetailsMapper fileDetailsMapper;
-    private CurrentTimestampGenerator timestampGenerator;
-    private ConfirmationReferenceGeneratorService confirmationReferenceGenerator;
-    private FormTemplateService formTemplateService;
-    private PaymentTemplateService paymentTemplateService;
-    private EmailService emailService;
-    private Validator<Submission> validator;
+    private final SubmissionRepository submissionRepository;
+    private final SubmissionMapper submissionMapper;
+    private final PresenterMapper presenterMapper;
+    private final CompanyMapper companyMapper;
+    private final FileDetailsMapper fileDetailsMapper;
+    private final CurrentTimestampGenerator timestampGenerator;
+    private final ConfirmationReferenceGeneratorService confirmationReferenceGenerator;
+    private final FormTemplateService formTemplateService;
+    private final PaymentTemplateService paymentTemplateService;
+    private final EmailService emailService;
+    private final Validator<Submission> validator;
     private final Clock clock;
 
 
@@ -99,8 +95,8 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     @Override
-    public SubmissionApi readSubmission(String id) {
-        Submission submission = submissionRepository.read(id);
+    public SubmissionApi readSubmission(final String id) {
+        final var submission = submissionRepository.read(id);
         if (submission != null) {
             return submissionMapper.map(submission);
         } else {
@@ -109,13 +105,13 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     @Override
-    public SubmissionResponseApi createSubmission(PresenterApi presenterApi) {
+    public SubmissionResponseApi createSubmission(final PresenterApi presenterApi) {
         LOGGER.debug("Attempting to create a submission with email: [%s]".formatted(presenterApi.getEmail()));
-        Presenter presenter = presenterMapper.map(presenterApi);
-        LocalDateTime timestamp = timestampGenerator.generateTimestamp();
-        String confirmRef = confirmationReferenceGenerator.generateId();
-        Submission submission = Submission.builder().withConfirmationReference(confirmRef).withPresenter(presenter)
-                .withStatus(SubmissionStatus.OPEN).withCreatedAt(timestamp).withLastModifiedAt(timestamp).build();
+        final var presenter = presenterMapper.map(presenterApi);
+        final var timestamp = timestampGenerator.generateTimestamp();
+        final var confirmRef = confirmationReferenceGenerator.generateId();
+        final var submission = Submission.builder().withConfirmationReference(confirmRef).withPresenter(presenter)
+                                   .withStatus(SubmissionStatus.OPEN).withCreatedAt(timestamp).withLastModifiedAt(timestamp).build();
         submissionRepository.create(submission);
         LOGGER.debug(
             "Successfully created a submission with email: [%s] and id: [%s] at [%s]".formatted(
@@ -125,42 +121,56 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     @Override
-    public SubmissionResponseApi updateSubmissionWithCompany(String id, CompanyApi companyApi) {
+    public SubmissionResponseApi updateSubmissionWithCompany(final String id, final CompanyApi companyApi) {
         LOGGER.debug("Attempting to update company details for submission with id: [%s]".formatted(id));
-        Submission updatedSubmission = Submission.builder(this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES)).withCompany(companyMapper.map(companyApi)).build();
+        final var updatedSubmission = Submission.builder(this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES)).withCompany(companyMapper.map(companyApi)).build();
         submissionRepository.updateSubmission(updatedSubmission);
         LOGGER.debug("Successfully updated company details for submission with id: [%s]".formatted(id));
         return new SubmissionResponseApi(id);
     }
 
     @Override
-    public SubmissionResponseApi updateSubmissionWithForm(String id, FormTypeApi formApi) {
+    public SubmissionResponseApi updateSubmissionWithForm(final String id, final FormTypeApi formApi) {
         LOGGER.debug("Attempting to update form type for submission with id: [%s]".formatted(id));
-        Submission submission = this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES);
-        FormDetails formDetails = submission.getFormDetails();
-        final String formType = formApi.getFormType();
+        final var submission = this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES);
+        var formDetails = submission.getFormDetails();
+        final var formType = formApi.getFormType();
         if (formDetails == null) {
             formDetails = FormDetails.builder().withFormType(formType).build();
         } else {
             formDetails.setFormType(formType);
         }
         LOGGER.debug("Attempting to update fee for submission with id: [%s]".formatted(id));
-        Submission updatedSubmission = Submission.builder(submission).withFeeOnSubmission(getPaymentCharge(formType)).withFormDetails(formDetails).build();
+        final var updatedSubmission = Submission.builder(submission).withFeeOnSubmission(getPaymentCharge(formType)).withFormDetails(formDetails).build();
         submissionRepository.updateSubmission(updatedSubmission);
         LOGGER.debug("Successfully updated form type for submission with id: [%s]".formatted(id));
         return new SubmissionResponseApi(id);
     }
 
     @Override
-    public SubmissionResponseApi updateSubmissionWithFileDetails(String id, FileListApi fileListApi) {
+    public SubmissionResponseApi clearSubmissionFiles(final String id) {
+        LOGGER.debug("Attempting to clear file details for submission with id: [%s]".formatted(id));
+        final var submission = this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES);
+        final var formDetails = submission.getFormDetails();
+        if (formDetails != null) {
+            formDetails.setFileDetailsList(null);
+        }
+        final var updatedSubmission = Submission.builder(submission).withFormDetails(formDetails).build();
+        submissionRepository.updateSubmission(updatedSubmission);
+        LOGGER.debug("Successfully cleared file details for submission with id: [%s]".formatted(id));
+        return new SubmissionResponseApi(id);
+    }
+
+    @Override
+    public SubmissionResponseApi updateSubmissionWithFileDetails(final String id, final FileListApi fileListApi) {
         LOGGER.debug("Attempting to update file details for submission with id: [%s]".formatted(id));
-        FormDetails formDetails = this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES).getFormDetails();
+        var formDetails = this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES).getFormDetails();
         if (formDetails == null) {
             formDetails = FormDetails.builder().withFileDetailsList(fileDetailsMapper.map(fileListApi)).build();
         } else {
             formDetails.setFileDetailsList(fileDetailsMapper.map(fileListApi));
         }
-        Submission updatedSubmission = Submission.builder(this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES)).withFormDetails(formDetails).build();
+        final var updatedSubmission = Submission.builder(this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES)).withFormDetails(formDetails).build();
         submissionRepository.updateSubmission(updatedSubmission);
         LOGGER.debug("Successfully updated file details for submission with id: [%s]".formatted(id));
 
@@ -168,12 +178,12 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     @Override
-    public SubmissionResponseApi updateSubmissionWithPaymentSessions(String id,
-        SessionListApi paymentSessions) {
+    public SubmissionResponseApi updateSubmissionWithPaymentSessions(final String id,
+        final SessionListApi paymentSessions) {
         LOGGER.debug(
             "Attempting to update payment sessions for submission with id: [%s]".formatted(
                 id));
-        Submission updatedSubmission = Submission.builder(this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES)).withPaymentSessions(paymentSessions).build();
+        final var updatedSubmission = Submission.builder(this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES)).withPaymentSessions(paymentSessions).build();
         submissionRepository.updateSubmission(updatedSubmission);
 
         return new SubmissionResponseApi(id);
@@ -182,14 +192,14 @@ public class SubmissionServiceImpl implements SubmissionService {
     @Override
     public SubmissionResponseApi updateSubmissionWithPaymentOutcome(final String id,
         final PaymentClose paymentClose) {
-        final Submission submission = getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES);
-        final SubmissionStatus status = submission.getStatus();
+        final var submission = getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES);
+        final var status = submission.getStatus();
 
         setPaymentSessionStatus(submission, paymentClose);
         LOGGER.debug("Updating submission status %s for submission with id: [%s]".formatted(status, submission.getId()));
 
         if (SubmissionStatus.PAYMENT_REQUIRED == submission.getStatus()) {
-            SubmissionStatus resultStatus;
+            final SubmissionStatus resultStatus;
 
             if (paymentClose.isPaid()) {
                 resultStatus = SubmissionStatus.SUBMITTED;
@@ -199,9 +209,9 @@ public class SubmissionServiceImpl implements SubmissionService {
                 return new SubmissionResponseApi(id);
             }
 
-            final LocalDateTime lastModified = timestampGenerator.generateTimestamp();
-            Submission updatedSubmission;
-            Submission.Builder builder = Submission.builder(submission).withStatus(resultStatus).withLastModifiedAt(lastModified);
+            final var lastModified = timestampGenerator.generateTimestamp();
+            final Submission updatedSubmission;
+            var builder = Submission.builder(submission).withStatus(resultStatus).withLastModifiedAt(lastModified);
             if (resultStatus == SubmissionStatus.SUBMITTED) {
                 builder = builder.withSubmittedAt(lastModified);
             }
@@ -219,7 +229,7 @@ public class SubmissionServiceImpl implements SubmissionService {
         LOGGER.debug("Attempting to update payment session outcome for submission with id: [%s]".formatted(
             submission.getId()));
 
-        final Optional<SessionApi> matchedSession =
+        final var matchedSession =
             Optional.ofNullable(submission.getPaymentSessions()).stream().flatMap(Collection::stream)
                 .filter(
                     s -> Objects.equals(s.getSessionId(), paymentClose.getPaymentReference()))
@@ -230,20 +240,20 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     @Override
-    public SubmissionResponseApi completeSubmission(String id)
+    public SubmissionResponseApi completeSubmission(final String id)
         throws SubmissionValidationException {
 
         LOGGER.debug("Attempting to complete submission for id: [%s]".formatted(id));
 
-        Submission submission = this.getSubmissionWithCheckedStatus(id, VALIDATABLE_STATUSES);
+        var submission = this.getSubmissionWithCheckedStatus(id, VALIDATABLE_STATUSES);
 
         // check submission mandatory fields (validator)
         try {
             validator.validate(submission);
-        } catch (SubmissionValidationException ve) {
+        } catch (final SubmissionValidationException ve) {
             LOGGER.info(ve.getMessage());
 
-            final Map<String, Object> debug = getDebugMap(id);
+            final var debug = getDebugMap(id);
 
             debug.put("exceptionMessage", ve.getMessage());
             LOGGER.errorContext(id, "Submission invalid ", null, debug);
@@ -252,7 +262,7 @@ public class SubmissionServiceImpl implements SubmissionService {
 
         if (submission.getFeeOnSubmission() == null) {
 
-            Submission updatedSubmission = progressSubmissionStatusToSubmitted(submission);
+            final var updatedSubmission = progressSubmissionStatusToSubmitted(submission);
 
             updateSubmission(updatedSubmission);
             LOGGER.debug("Successfully completed submission for id: [%s]".formatted(id));
@@ -266,7 +276,7 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     private Submission progressSubmissionStatusToSubmitted(final Submission submission) {
-        final SubmissionStatus status = submission.getStatus();
+        final var status = submission.getStatus();
 
         LOGGER.debug("Updating submission status %s for submission with id: [%s]".formatted(
             status, submission.getId()));
@@ -274,8 +284,8 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     private Submission updateAsSubmitted(final Submission submission) {
-        final LocalDateTime lastModified = timestampGenerator.generateTimestamp();
-        Submission updatedSubmission = Submission.builder(submission).withStatus(SubmissionStatus.SUBMITTED).withSubmittedAt(lastModified).build();
+        final var lastModified = timestampGenerator.generateTimestamp();
+        final var updatedSubmission = Submission.builder(submission).withStatus(SubmissionStatus.SUBMITTED).withSubmittedAt(lastModified).build();
         LOGGER.debug(
             SUBMISSION_STATUS_MSG.formatted(SubmissionStatus.SUBMITTED, updatedSubmission.getId(),
                 DateTimeFormatter.ISO_INSTANT.format(lastModified.atZone(ZoneId.of("UTC")))));
@@ -283,9 +293,9 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     @Override
-    public SubmissionResponseApi updateSubmissionQueued(Submission submission) {
-        LocalDateTime timestamp = timestampGenerator.generateTimestamp();
-        Submission updatedSubmission = Submission.builder(submission).withStatus(SubmissionStatus.PROCESSING).withLastModifiedAt(timestamp).build();
+    public SubmissionResponseApi updateSubmissionQueued(final Submission submission) {
+        final var timestamp = timestampGenerator.generateTimestamp();
+        final var updatedSubmission = Submission.builder(submission).withStatus(SubmissionStatus.PROCESSING).withLastModifiedAt(timestamp).build();
         updatedSubmission.getFormDetails()
             .getFileDetailsList()
             .forEach(fileDetails -> this.handleFile(fileDetails, timestamp));
@@ -298,13 +308,13 @@ public class SubmissionServiceImpl implements SubmissionService {
         return new SubmissionResponseApi(submission.getId());
     }
 
-    private void handleFile(FileDetails fileDetails, LocalDateTime timestamp) {
+    private void handleFile(final FileDetails fileDetails, final LocalDateTime timestamp) {
         fileDetails.setConversionStatus(FileConversionStatus.QUEUED);
         fileDetails.setLastModifiedAt(timestamp);
     }
 
     @Override
-    public SubmissionResponseApi updateSubmissionBarcode(String id, String barcode) {
+    public SubmissionResponseApi updateSubmissionBarcode(final String id, final String barcode) {
         LOGGER.debug(String.format("Attempting to update barcode for submission with id: [%s]", id));
         submissionRepository.updateBarcode(id, barcode);
         LOGGER.debug("Updated barcode for submission with id: [%s]".formatted(id));
@@ -312,7 +322,7 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     @Override
-    public SubmissionResponseApi updateSubmissionStatus(String id, SubmissionStatus status) {
+    public SubmissionResponseApi updateSubmissionStatus(final String id, final SubmissionStatus status) {
         LOGGER.debug("Attempting to update status for submission with id: [%s]".formatted(id));
         submissionRepository.updateSubmissionStatus(id, status);
         LOGGER.debug("Updated status for submission with id: [%s]".formatted(id));
@@ -322,32 +332,32 @@ public class SubmissionServiceImpl implements SubmissionService {
     @Override
     public SubmissionResponseApi updateSubmissionConfirmAuthorised(final String id, final Boolean confirmAuthorised) {
         LOGGER.debug("Attempting to update authorised for submission with id: [%s]".formatted(id));
-        Submission submission = this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES);
-        Submission updatedSubmission = Submission.builder(submission).withConfirmAuthorised(confirmAuthorised).build();
+        final var submission = this.getSubmissionWithCheckedStatus(id, UPDATABLE_STATUSES);
+        final var updatedSubmission = Submission.builder(submission).withConfirmAuthorised(confirmAuthorised).build();
         submissionRepository.updateSubmission(updatedSubmission);
         LOGGER.debug("Successfully updated confirm authorised for submission with id: [%s]".formatted(id));
         return new SubmissionResponseApi(id);
     }
 
     @Override
-    public void updateSubmission(Submission submission) {
+    public void updateSubmission(final Submission submission) {
         LOGGER.debug(
             "Attempting to update submission with id: [%s]".formatted(submission.getId()));
-        final LocalDateTime lastModified = timestampGenerator.generateTimestamp();
-        Submission updatedSubmission = Submission.builder(submission).withLastModifiedAt(lastModified).build();
+        final var lastModified = timestampGenerator.generateTimestamp();
+        final var updatedSubmission = Submission.builder(submission).withLastModifiedAt(lastModified).build();
         submissionRepository.updateSubmission(updatedSubmission);
         LOGGER.debug("Updated submission with id: [%s] at [%s]".formatted(submission.getId(),
             DateTimeFormatter.ISO_INSTANT.format(lastModified.atZone(ZoneId.of("UTC")))));
     }
 
 
-    private Submission getSubmissionWithCheckedStatus(String id,
+    private Submission getSubmissionWithCheckedStatus(final String id,
         final Set<SubmissionStatus> acceptableStatusSet) {
 
-        Submission submission = submissionRepository.read(id);
+        final var submission = submissionRepository.read(id);
 
         // check if submission exists and has the correct status
-        final Map<String, Object> debugMap = getDebugMap(id);
+        final var debugMap = getDebugMap(id);
 
         if (submission == null) {
             LOGGER.errorContext(id, "Could not locate submission", null, debugMap);
@@ -365,19 +375,19 @@ public class SubmissionServiceImpl implements SubmissionService {
     }
 
     private String getPaymentCharge(final String formType) {
-        final FormTemplateApi formTemplate = formType != null ? formTemplateService.getFormTemplate(formType) : null;
+        final var formTemplate = formType != null ? formTemplateService.getFormTemplate(formType) : null;
         String result = null;
-        final LocalDateTime now = LocalDateTime.now(clock);
+        final var now = LocalDateTime.now(clock);
 
         if (formTemplate != null) {
-            final String paymentCharge = formTemplate.getPaymentCharge();
+            final var paymentCharge = formTemplate.getPaymentCharge();
 
             if (StringUtils.isNotBlank(paymentCharge)) {
 
                 LOGGER.debug("Payment fee at [%s] for form [%s] is [%s]".formatted(
                     DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(now), formType, paymentCharge));
 
-                final Optional<PaymentTemplate> template = paymentTemplateService.getPaymentTemplate(paymentCharge, now);
+                final var template = paymentTemplateService.getPaymentTemplate(paymentCharge, now);
 
                 result = template.map(t -> t.getItems().getFirst().getAmount()).orElse(null);
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -103,6 +103,12 @@ env.name=${ENV_NAME}
 scotland.company.prefixes=${SCOTLAND_COMPANY_PREFIXES}
 northernIreland.company.prefixes=${NORTHERN_IRELAND_COMPANY_PREFIXES}
 
+# ASYNC PROCESSING
+# (S3 FILE DELETION)
+async.executor.core-pool-size=${ASYNC_EXECUTOR_CORE_POOL_SIZE}
+async.executor.max-pool-size=${ASYNC_EXECUTOR_MAX_POOL_SIZE}
+async.executor.queue-capacity=${ASYNC_EXECUTOR_QUEUE_CAPACITY}
+
 # OUT_OF_SERVICE PERIOD
 out-of-service.period.start=${PLANNED_MAINTENANCE_START_TIME:}
 out-of-service.period.end=${PLANNED_MAINTENANCE_END_TIME:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -110,6 +110,8 @@ async.executor.max-pool-size=${ASYNC_EXECUTOR_MAX_POOL_SIZE}
 async.executor.queue-capacity=${ASYNC_EXECUTOR_QUEUE_CAPACITY}
 async.executor.keep-alive-seconds=${ASYNC_EXECUTOR_KEEP_ALIVE_SECONDS}
 async.executor.allow-core-thread-timeout=${ASYNC_EXECUTOR_ALLOW_CORE_THREAD_TIMEOUT}
+async.executor.wait-for-tasks-to-complete-on-shutdown=${ASYNC_EXECUTOR_WAIT_FOR_TASKS_TO_COMPLETE_ON_SHUTDOWN}
+async.executor.await-termination-seconds=${ASYNC_EXECUTOR_AWAIT_TERMINATION_SECONDS}
 
 # OUT_OF_SERVICE PERIOD
 out-of-service.period.start=${PLANNED_MAINTENANCE_START_TIME:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,6 +108,8 @@ northernIreland.company.prefixes=${NORTHERN_IRELAND_COMPANY_PREFIXES}
 async.executor.core-pool-size=${ASYNC_EXECUTOR_CORE_POOL_SIZE}
 async.executor.max-pool-size=${ASYNC_EXECUTOR_MAX_POOL_SIZE}
 async.executor.queue-capacity=${ASYNC_EXECUTOR_QUEUE_CAPACITY}
+async.executor.keep-alive-seconds=${ASYNC_EXECUTOR_KEEP_ALIVE_SECONDS}
+async.executor.allow-core-thread-timeout=${ASYNC_EXECUTOR_ALLOW_CORE_THREAD_TIMEOUT}
 
 # OUT_OF_SERVICE PERIOD
 out-of-service.period.start=${PLANNED_MAINTENANCE_START_TIME:}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImplAsyncITest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImplAsyncITest.java
@@ -1,0 +1,122 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+/**
+ * Integration test verifying that {@link S3FileDeleteServiceImpl#deleteFile} returns
+ * to the caller immediately, with the S3 delete executing on a background thread.
+ *
+ * <p>A {@link CountDownLatch} gates the mock S3 client so it cannot complete until
+ * the test releases it. This lets the test assert that the caller has already returned
+ * before the S3 operation finishes, proving async dispatch.</p>
+ */
+@SpringJUnitConfig
+class S3FileDeleteServiceImplAsyncITest {
+
+    private static final String SUBMISSION_ID = "submission-id";
+    private static final String FILE_ID = "file-id";
+    private static final long TIMEOUT_MS = 5_000L;
+
+    @Configuration
+    @EnableAsync
+    static class TestConfig {
+
+        @Bean
+        S3Client s3Client() {
+            return mock(S3Client.class);
+        }
+
+        @Bean
+        S3FileDeleteService s3FileDeleteService(final S3Client s3Client) {
+            return new S3FileDeleteServiceImpl(s3Client, "test-bucket");
+        }
+
+        @Bean(name = "threadPoolTaskExecutor")
+        Executor threadPoolTaskExecutor() {
+            final var executor = new ThreadPoolTaskExecutor();
+            executor.setCorePoolSize(1);
+            executor.setMaxPoolSize(2);
+            executor.setQueueCapacity(5);
+            executor.setThreadNamePrefix("test-async-s3-");
+            executor.initialize();
+            return executor;
+        }
+    }
+
+    @Autowired
+    private S3FileDeleteService s3FileDeleteService;
+
+    @Autowired
+    private S3Client s3Client;
+
+    @Test
+    void shouldReturnBeforeS3DeleteCompletesWhenAsyncIsEnabled() {
+        final var s3Release = new CountDownLatch(1);
+        final var s3Completed = new AtomicBoolean(false);
+
+        doAnswer(inv -> {
+            final var released = s3Release.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            assertThat("latch should be released before timeout", released, is(true));
+            s3Completed.set(true);
+            return null;
+        }).when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+        // If @Async is active, this returns before the S3 mock runs
+        s3FileDeleteService.deleteFile(SUBMISSION_ID, FILE_ID);
+
+        // Caller has returned; S3 is still blocked on the latch
+        assertThat("caller should return before S3 delete completes", s3Completed.get(), is(false));
+
+        // Release S3 and poll until the background thread completes
+        s3Release.countDown();
+        await("S3 delete should complete once released")
+            .atMost(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .untilTrue(s3Completed);
+    }
+
+    @Test
+    void shouldReturnBeforeS3ThrowsWhenAsyncIsEnabled() {
+        final var s3Release = new CountDownLatch(1);
+        final var s3Completed = new AtomicBoolean(false);
+
+        doAnswer(inv -> {
+            final var released = s3Release.await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+            assertThat("latch should be released before timeout", released, is(true));
+            s3Completed.set(true);
+            throw SdkException.builder().message("S3 error").build();
+        }).when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+        // If @Async is active, this returns before the S3 mock runs
+        s3FileDeleteService.deleteFile(SUBMISSION_ID, FILE_ID);
+
+        // Caller has returned; S3 is still blocked on the latch
+        assertThat("caller should return before S3 starts", s3Completed.get(), is(false));
+
+        // Release and poll until the async thread has handled the error
+        s3Release.countDown();
+        await("async thread should complete error handling without rethrowing")
+            .atMost(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .untilTrue(s3Completed);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImplTest.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.efs.api.events.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileDeleteServiceImplTest {
+
+    private static final String BUCKET_NAME = "file-bucket";
+    private static final String SUBMISSION_ID = "submission-id";
+    private static final String FILE_ID = "file-id";
+
+    @Mock
+    private S3Client s3Client;
+
+    @Captor
+    private ArgumentCaptor<DeleteObjectRequest> deleteObjectRequestCaptor;
+
+    private S3FileDeleteServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        this.service = new S3FileDeleteServiceImpl(s3Client, BUCKET_NAME);
+    }
+
+    @Test
+    void shouldDeleteFileFromS3WhenCalledWithFileId() {
+        service.deleteFile(SUBMISSION_ID, FILE_ID);
+
+        verify(s3Client).deleteObject(deleteObjectRequestCaptor.capture());
+        final var request = deleteObjectRequestCaptor.getValue();
+        org.junit.jupiter.api.Assertions.assertAll(
+            () -> org.junit.jupiter.api.Assertions.assertEquals(BUCKET_NAME, request.bucket()),
+            () -> org.junit.jupiter.api.Assertions.assertEquals(FILE_ID, request.key())
+        );
+    }
+
+    @Test
+    void shouldNotThrowWhenS3DeleteFails() {
+        doThrow(SdkException.class).when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+        assertDoesNotThrow(() -> service.deleteFile(SUBMISSION_ID, FILE_ID));
+        verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/events/service/S3FileDeleteServiceImplTest.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.efs.api.events.service;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -41,11 +43,11 @@ class S3FileDeleteServiceImplTest {
         service.deleteFile(SUBMISSION_ID, FILE_ID);
 
         verify(s3Client).deleteObject(deleteObjectRequestCaptor.capture());
+
         final var request = deleteObjectRequestCaptor.getValue();
-        org.junit.jupiter.api.Assertions.assertAll(
-            () -> org.junit.jupiter.api.Assertions.assertEquals(BUCKET_NAME, request.bucket()),
-            () -> org.junit.jupiter.api.Assertions.assertEquals(FILE_ID, request.key())
-        );
+
+        assertThat(request.bucket(), is(BUCKET_NAME));
+        assertThat(request.key(), is(FILE_ID));
     }
 
     @Test
@@ -53,6 +55,7 @@ class S3FileDeleteServiceImplTest {
         doThrow(SdkException.class).when(s3Client).deleteObject(any(DeleteObjectRequest.class));
 
         assertDoesNotThrow(() -> service.deleteFile(SUBMISSION_ID, FILE_ID));
+
         verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/controller/ConfirmFormTypeControllerTest.java
@@ -3,20 +3,27 @@ package uk.gov.companieshouse.efs.api.submissions.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.api.model.efs.submissions.FileDetailApi;
+import uk.gov.companieshouse.api.model.efs.submissions.FileDetailListApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FormTypeApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
+import uk.gov.companieshouse.api.model.efs.submissions.SubmissionFormApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionResponseApi;
-import uk.gov.companieshouse.efs.api.submissions.model.Submission;
+import uk.gov.companieshouse.efs.api.events.service.S3FileDeleteService;
 import uk.gov.companieshouse.efs.api.submissions.service.SubmissionService;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionIncorrectStateException;
 import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionNotFoundException;
@@ -24,38 +31,51 @@ import uk.gov.companieshouse.efs.api.submissions.service.exception.SubmissionNot
 @ExtendWith(MockitoExtension.class)
 class ConfirmFormTypeControllerTest {
 
-    @Mock
-    private SubmissionResponseApi response;
+    private static final String SUBMISSION_ID = "submission-id";
 
     private ConfirmFormTypeController confirmFormTypeController;
-
-    @Mock
-    private FormTypeApi formType;
 
     @Mock
     private SubmissionService service;
 
     @Mock
-    private Submission submission;
+    private SubmissionResponseApi response;
+
+    @Mock
+    private S3FileDeleteService s3FileDeleteService;
 
     @Mock
     private BindingResult result;
 
+    @Mock
+    private SubmissionApi submissionApi;
+
+    @Mock
+    private SubmissionFormApi submissionFormApi;
+
+    @Mock
+    private FileDetailListApi fileDetailListApi;
+
+    @Mock
+    private FileDetailApi fileDetailApiOne;
+
+    @Mock
+    private FileDetailApi fileDetailApiTwo;
+
     @BeforeEach
     void setUp() {
-        this.confirmFormTypeController = new ConfirmFormTypeController(service);
+        this.confirmFormTypeController = new ConfirmFormTypeController(service, s3FileDeleteService);
     }
 
     @Test
     void testConfirmFormTypeReturnsSubmissionId() {
-        //given
-        when(service.updateSubmissionWithForm(any(), any())).thenReturn(response);
+        final var formType = createFormType("NEW-FORM-TYPE");
+        stubNoValidationErrors();
+        stubSuccessfulFormUpdate();
 
-        //when
-        ResponseEntity<SubmissionResponseApi> actual = confirmFormTypeController.confirmFormType("123", formType,
-                result);
+        final var actual = confirmFormTypeController.confirmFormType(SUBMISSION_ID, formType,
+            result);
 
-        //then
         assertEquals(response, actual.getBody());
         assertEquals(HttpStatus.OK, actual.getStatusCode());
     }
@@ -63,44 +83,109 @@ class ConfirmFormTypeControllerTest {
 
     @Test
     void testConfirmFormTypeReturns409Conflict() {
-        //given
+        final var formType = createFormType("NEW-FORM-TYPE");
+        stubNoValidationErrors();
         when(service.updateSubmissionWithForm(any(), any())).thenThrow(new SubmissionIncorrectStateException("not OPEN"));
 
-        //when
-        ResponseEntity<SubmissionResponseApi> actual = confirmFormTypeController.confirmFormType("123", formType, result);
+        final var actual = confirmFormTypeController.confirmFormType(SUBMISSION_ID, formType, result);
 
-        //then
         assertNull(actual.getBody());
         assertEquals(HttpStatus.CONFLICT, actual.getStatusCode());
     }
 
     @Test
     void testConfirmFormTypeReturns400BadRequest() {
-        // given
+        final var formType = createFormType("NEW-FORM-TYPE");
         when(result.hasErrors()).thenReturn(true);
         when(result.getFieldError()).thenReturn(new FieldError("a", "form.formType", "invalid"));
 
-        // when
-        ResponseEntity<SubmissionResponseApi> actual = confirmFormTypeController.confirmFormType("123", formType,
-                result);
+        final var actual = confirmFormTypeController.confirmFormType(SUBMISSION_ID, formType,
+            result);
 
-        // then
         assertNull(actual.getBody());
         assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode());
     }
 
     @Test
     void testConfirmFormTypeReturns404NotFound() {
-        // given
+        final var formType = createFormType("NEW-FORM-TYPE");
+        stubNoValidationErrors();
         when(service.updateSubmissionWithForm(any(), any())).thenThrow(new SubmissionNotFoundException("not found"));
 
-        // when
-        ResponseEntity<SubmissionResponseApi> actual = confirmFormTypeController.confirmFormType("123", formType,
-                result);
+        final var actual = confirmFormTypeController.confirmFormType(SUBMISSION_ID, formType,
+            result);
 
-        // then
         assertNull(actual.getBody());
         assertEquals(HttpStatus.NOT_FOUND, actual.getStatusCode());
     }
 
+    @Test
+    void shouldDeleteFilesAndClearSubmissionWhenFormTypeChanges() {
+        final var formType = createFormType("NEW-FORM-TYPE");
+        stubNoValidationErrors();
+        stubExistingSubmissionFormType("OLD-FORM-TYPE");
+        stubExistingSubmissionFiles("file-1", "file-2");
+        stubSuccessfulFormUpdate();
+
+        final var actual = confirmFormTypeController.confirmFormType(SUBMISSION_ID, formType, result);
+
+        assertEquals(HttpStatus.OK, actual.getStatusCode());
+        assertEquals(response, actual.getBody());
+        verify(s3FileDeleteService).deleteFile(SUBMISSION_ID, "file-1");
+        verify(s3FileDeleteService).deleteFile(SUBMISSION_ID, "file-2");
+        verify(service).clearSubmissionFiles(SUBMISSION_ID);
+    }
+
+    @Test
+    void shouldNotDeleteFilesWhenFormTypeIsUnchanged() {
+        final var formType = createFormType("SAME-FORM-TYPE");
+        stubNoValidationErrors();
+        stubExistingSubmissionFormType("SAME-FORM-TYPE");
+        stubSuccessfulFormUpdate();
+
+        final var actual = confirmFormTypeController.confirmFormType(SUBMISSION_ID, formType, result);
+
+        assertEquals(HttpStatus.OK, actual.getStatusCode());
+        verifyNoInteractions(s3FileDeleteService);
+        verify(service, never()).clearSubmissionFiles(any());
+    }
+
+    @Test
+    void shouldNotDeleteFilesWhenExistingFormTypeIsNull() {
+        final var formType = createFormType("NEW-FORM-TYPE");
+        stubNoValidationErrors();
+        stubExistingSubmissionFormType(null);
+        stubSuccessfulFormUpdate();
+
+        final var actual = confirmFormTypeController.confirmFormType(SUBMISSION_ID, formType, result);
+
+        assertEquals(HttpStatus.OK, actual.getStatusCode());
+        verifyNoInteractions(s3FileDeleteService);
+        verify(service, never()).clearSubmissionFiles(any());
+    }
+
+    private FormTypeApi createFormType(final String formType) {
+        return new FormTypeApi(formType);
+    }
+
+    private void stubNoValidationErrors() {
+        when(result.hasErrors()).thenReturn(false);
+    }
+
+    private void stubSuccessfulFormUpdate() {
+        when(service.updateSubmissionWithForm(any(), any())).thenReturn(response);
+    }
+
+    private void stubExistingSubmissionFormType(final String existingFormType) {
+        when(service.readSubmission(SUBMISSION_ID)).thenReturn(submissionApi);
+        when(submissionApi.getSubmissionForm()).thenReturn(submissionFormApi);
+        when(submissionFormApi.getFormType()).thenReturn(existingFormType);
+    }
+
+    private void stubExistingSubmissionFiles(final String fileIdOne, final String fileIdTwo) {
+        when(submissionFormApi.getFileDetails()).thenReturn(fileDetailListApi);
+        when(fileDetailListApi.getList()).thenReturn(List.of(fileDetailApiOne, fileDetailApiTwo));
+        when(fileDetailApiOne.getFileId()).thenReturn(fileIdOne);
+        when(fileDetailApiTwo.getFileId()).thenReturn(fileIdTwo);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/api/submissions/service/SubmissionServiceImplTest.java
@@ -1,9 +1,31 @@
 package uk.gov.companieshouse.efs.api.submissions.service;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +42,6 @@ import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FormTypeApi;
 import uk.gov.companieshouse.api.model.efs.submissions.PresenterApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
-import uk.gov.companieshouse.api.model.efs.submissions.SubmissionResponseApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionStatus;
 import uk.gov.companieshouse.api.model.paymentsession.SessionApi;
 import uk.gov.companieshouse.api.model.paymentsession.SessionListApi;
@@ -46,46 +67,20 @@ import uk.gov.companieshouse.efs.api.submissions.validator.Validator;
 import uk.gov.companieshouse.efs.api.submissions.validator.exception.SubmissionValidationException;
 import uk.gov.companieshouse.efs.api.util.CurrentTimestampGenerator;
 
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class SubmissionServiceImplTest {
-    public static final String SESSION_ID = "2222222222";
-    public static final String SESSION_STATE =
+    public static final String PAY_SESSION_ID = "2222222222";
+    public static final String PAY_SESSION_STATE =
         "FD_RlzcLp-xcK1YZGEbn3ZpRHGlwy7tNjn_zsjYVauoB8Ml3GkfpmbhPuPd093XM";
-    private static final String SUBMISSION_ID = "123";
+    private static final String SUBMISSION_ID = "submission-id";
     public static final String STATUS_PAID = PaymentClose.Status.PAID.toString();
     private static final String STATUS_FAILED = PaymentClose.Status.FAILED.toString();
     private static final String STATUS_CANCELLED = PaymentClose.Status.CANCELLED.toString();
     public static final String EXPECTED_UPDATE_ERROR_MSG =
-        "Submission status for [123] wasn't in [OPEN, PAYMENT_REQUIRED, "
-            + "PAYMENT_FAILED], couldn't update";
+        "Submission status for [%s] wasn't in [OPEN, PAYMENT_REQUIRED, PAYMENT_FAILED], couldn't update".formatted(SUBMISSION_ID);
 
     public static final String EXPECTED_COMPLETE_ERROR_MSG =
-        "Submission status for [123] wasn't in [OPEN, PAYMENT_REQUIRED, "
-            + "PAYMENT_FAILED, SUBMITTED], couldn't update";
+        "Submission status for [%s] wasn't in [OPEN, PAYMENT_REQUIRED, PAYMENT_FAILED, SUBMITTED], couldn't update".formatted(SUBMISSION_ID);
     private static final LocalDateTime NOW = LocalDateTime.now();
 
     private SubmissionService submissionService;
@@ -139,8 +134,8 @@ class SubmissionServiceImplTest {
     @Test
     void testCreateSubmission() {
         // given
-        PresenterApi presenterApi = mock(PresenterApi.class);
-        Presenter presenter = mock(Presenter.class);
+        final var presenterApi = mock(PresenterApi.class);
+        final var presenter = mock(Presenter.class);
         when(presenterMapper.map(presenterApi)).thenReturn(presenter);
         when(timestampGenerator.generateTimestamp()).thenReturn(NOW);
 
@@ -157,14 +152,14 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithCompany() {
         // given
-        CompanyApi companyApi = mock(CompanyApi.class);
-        Company company = mock(Company.class);
+        final var companyApi = mock(CompanyApi.class);
+        final var company = mock(Company.class);
         when(companyMapper.map(companyApi)).thenReturn(company);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithCompany(SUBMISSION_ID, companyApi);
+        final var actual = submissionService.updateSubmissionWithCompany(SUBMISSION_ID, companyApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -175,15 +170,15 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithCompanyNotFound() {
         // given
-        CompanyApi companyApi = mock(CompanyApi.class);
+        final var companyApi = mock(CompanyApi.class);
         when(submissionRepository.read(anyString())).thenReturn(null);
 
         // when
-        Executable actual = () -> submissionService.updateSubmissionWithCompany(SUBMISSION_ID, companyApi);
+        final Executable actual = () -> submissionService.updateSubmissionWithCompany(SUBMISSION_ID, companyApi);
 
         // then
-        SubmissionNotFoundException ex = assertThrows(SubmissionNotFoundException.class, actual);
-        assertEquals("Could not locate submission with id: [123]", ex.getMessage());
+        final var ex = assertThrows(SubmissionNotFoundException.class, actual);
+        assertEquals("Could not locate submission with id: [%s]".formatted(SUBMISSION_ID), ex.getMessage());
         verifyNoInteractions(companyMapper);
     }
 
@@ -191,15 +186,15 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithCompanyIncorrectState() {
         // given
-        CompanyApi companyApi = mock(CompanyApi.class);
+        final var companyApi = mock(CompanyApi.class);
         when(submission.getStatus()).thenReturn(SubmissionStatus.PROCESSING);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        Executable actual = () -> submissionService.updateSubmissionWithCompany(SUBMISSION_ID, companyApi);
+        final Executable actual = () -> submissionService.updateSubmissionWithCompany(SUBMISSION_ID, companyApi);
 
         // then
-        SubmissionIncorrectStateException ex = assertThrows(SubmissionIncorrectStateException.class, actual);
+        final var ex = assertThrows(SubmissionIncorrectStateException.class, actual);
         assertEquals(EXPECTED_UPDATE_ERROR_MSG, ex.getMessage());
         verifyNoInteractions(companyMapper);
     }
@@ -207,17 +202,17 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithForm() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
+        final var formApi = mock(FormTypeApi.class);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission updateSubmission = submissionCaptor.getValue();
+        final var updateSubmission = submissionCaptor.getValue();
         assertThat(updateSubmission.getFeeOnSubmission(), is(equalTo(submission.getFeeOnSubmission())));
         assertThat(updateSubmission.getFormDetails().getFormType(), is(equalTo(formApi.getFormType())));
     }
@@ -225,19 +220,19 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFormWhenFormTypeNull() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
+        final var formApi = mock(FormTypeApi.class);
 
         when(formApi.getFormType()).thenReturn(null);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertThat(actual.getId(), is(SUBMISSION_ID));
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission expected = submissionCaptor.getValue();
+        final var expected = submissionCaptor.getValue();
         assertThat(expected.getFeeOnSubmission(), is(nullValue()));
         assertThat(expected.getFormDetails().getFormType(), is(nullValue()));
         verifyNoInteractions(formTemplateService, paymentTemplateService);
@@ -248,7 +243,7 @@ class SubmissionServiceImplTest {
     }
     @ParameterizedTest
     @MethodSource("provideScenariosForUpdateSubmissionWithForm")
-    void testUpdateSubmissionWithFormScenarios(FormTypeApi formType) {
+    void testUpdateSubmissionWithFormScenarios(final FormTypeApi formType) {
         // given
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
@@ -256,12 +251,12 @@ class SubmissionServiceImplTest {
         when(formDetails.getFormType()).thenReturn(formType.getFormType());
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formType);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formType);
 
         // then
         assertThat(actual.getId(), is(SUBMISSION_ID));
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission expected = submissionCaptor.getValue();
+        final var expected = submissionCaptor.getValue();
         if (formType.getFormType()==null) {
             assertThat(expected.getFeeOnSubmission(), is(nullValue()));
             assertThat(expected.getFormDetails().getFormType(), is(nullValue()));
@@ -277,14 +272,14 @@ class SubmissionServiceImplTest {
 
     @Test
     void  testUpdateSubmissionWithFormWhenFormDetailsNull() {
-        FormTypeApi formApi = mock(FormTypeApi.class);
+        final var formApi = mock(FormTypeApi.class);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
         when(submission.getFormDetails()).thenReturn(null);
         when(formApi.getFormType()).thenReturn("abc");
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertThat(actual.getId(), is(SUBMISSION_ID));
@@ -296,8 +291,8 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFormWhenFormTypeNotFound() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
-        final String FORM_TYPE = "NOT_FOUND";
+        final var formApi = mock(FormTypeApi.class);
+        final var FORM_TYPE = "NOT_FOUND";
 
         when(formApi.getFormType()).thenReturn(FORM_TYPE);
         when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(null);
@@ -305,7 +300,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -318,9 +313,9 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFormWhenPaymentChargeNull() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
-        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
-        final String FORM_TYPE = "NULL_CHARGE";
+        final var formApi = mock(FormTypeApi.class);
+        final var formTemplateApi = mock(FormTemplateApi.class);
+        final var FORM_TYPE = "NULL_CHARGE";
 
         when(formApi.getFormType()).thenReturn(FORM_TYPE);
         when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplateApi);
@@ -329,7 +324,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -340,10 +335,10 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFormWhenPaymentTemplateNotFound() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
-        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
-        final String FORM_TYPE = "NULL_CHARGE";
-        final String PAYMENT_TEMPLATE = "PAYMENT";
+        final var formApi = mock(FormTypeApi.class);
+        final var formTemplateApi = mock(FormTemplateApi.class);
+        final var FORM_TYPE = "NULL_CHARGE";
+        final var PAYMENT_TEMPLATE = "PAYMENT";
 
         when(formApi.getFormType()).thenReturn(FORM_TYPE);
         when(formTemplateService.getFormTemplate(FORM_TYPE)).thenReturn(formTemplateApi);
@@ -353,7 +348,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -363,12 +358,12 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFormWhenPaymentTemplateFound() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
-        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
-        final String FORM_TYPE = "NULL_CHARGE";
-        final String PAYMENT_TEMPLATE = "PAYMENT";
-        final String PAYMENT_CHARGE = "99";
-        final PaymentTemplate template =
+        final var formApi = mock(FormTypeApi.class);
+        final var formTemplateApi = mock(FormTemplateApi.class);
+        final var FORM_TYPE = "NULL_CHARGE";
+        final var PAYMENT_TEMPLATE = "PAYMENT";
+        final var PAYMENT_CHARGE = "99";
+        final var template =
             PaymentTemplate.newBuilder()
                 .withItem(PaymentTemplate.Item.newBuilder().withAmount(PAYMENT_CHARGE).build())
                 .build();
@@ -381,7 +376,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -391,13 +386,13 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFormWhereFormDetailsAlreadyExist() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
+        final var formApi = mock(FormTypeApi.class);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final var actual = submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -407,43 +402,43 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFormNotFound() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
+        final var formApi = mock(FormTypeApi.class);
         when(submissionRepository.read(anyString())).thenReturn(null);
 
         // when
-        Executable actual = () -> submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final Executable actual = () -> submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
-        SubmissionNotFoundException ex = assertThrows(SubmissionNotFoundException.class, actual);
-        assertEquals("Could not locate submission with id: [123]", ex.getMessage());
+        final var ex = assertThrows(SubmissionNotFoundException.class, actual);
+        assertEquals("Could not locate submission with id: [%s]".formatted(SUBMISSION_ID), ex.getMessage());
     }
 
     @Test
     void testUpdateSubmissionWithFormIncorrectState() {
         // given
-        FormTypeApi formApi = mock(FormTypeApi.class);
+        final var formApi = mock(FormTypeApi.class);
         when(submission.getStatus()).thenReturn(SubmissionStatus.PROCESSING);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        Executable actual = () -> submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
+        final Executable actual = () -> submissionService.updateSubmissionWithForm(SUBMISSION_ID, formApi);
 
         // then
-        SubmissionIncorrectStateException ex = assertThrows(SubmissionIncorrectStateException.class, actual);
+        final var ex = assertThrows(SubmissionIncorrectStateException.class, actual);
         assertEquals(EXPECTED_UPDATE_ERROR_MSG, ex.getMessage());
     }
 
     @Test
     void testUpdateSubmissionWithFiles() {
         // given
-        FileListApi fileListApi = mock(FileListApi.class);
-        List<FileDetails> fileDetailsList = Collections.singletonList(mock(FileDetails.class));
+        final var fileListApi = mock(FileListApi.class);
+        final var fileDetailsList = Collections.singletonList(mock(FileDetails.class));
         when(fileDetailsMapper.map(fileListApi)).thenReturn(fileDetailsList);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
+        final var actual = submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -454,15 +449,15 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFilesWhereFormDetailsAlreadyExist() {
         // given
-        FileListApi fileListApi = mock(FileListApi.class);
-        List<FileDetails> fileDetailsList = Collections.singletonList(mock(FileDetails.class));
+        final var fileListApi = mock(FileListApi.class);
+        final var fileDetailsList = Collections.singletonList(mock(FileDetails.class));
         when(fileDetailsMapper.map(fileListApi)).thenReturn(fileDetailsList);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submission.getFormDetails()).thenReturn(formDetails);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
+        final var actual = submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -473,73 +468,98 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithFilesNotFound() {
         // given
-        FileListApi fileListApi = mock(FileListApi.class);
+        final var fileListApi = mock(FileListApi.class);
         when(submissionRepository.read(anyString())).thenReturn(null);
 
         // when
-        Executable actual = () -> submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
+        final Executable actual = () -> submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
 
         // then
-        SubmissionNotFoundException ex = assertThrows(SubmissionNotFoundException.class, actual);
-        assertEquals("Could not locate submission with id: [123]", ex.getMessage());
+        final var ex = assertThrows(SubmissionNotFoundException.class, actual);
+        assertEquals("Could not locate submission with id: [%s]".formatted(SUBMISSION_ID), ex.getMessage());
         verifyNoInteractions(fileDetailsMapper);
     }
 
     @Test
     void testUpdateSubmissionWithFilesIncorrectState() {
         // given
-        FileListApi fileListApi = mock(FileListApi.class);
+        final var fileListApi = mock(FileListApi.class);
         when(submission.getStatus()).thenReturn(SubmissionStatus.PROCESSING);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        Executable actual = () -> submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
+        final Executable actual = () -> submissionService.updateSubmissionWithFileDetails(SUBMISSION_ID, fileListApi);
 
         // then
-        SubmissionIncorrectStateException ex = assertThrows(SubmissionIncorrectStateException.class, actual);
+        final var ex = assertThrows(SubmissionIncorrectStateException.class, actual);
         assertEquals(EXPECTED_UPDATE_ERROR_MSG, ex.getMessage());
         verifyNoInteractions(fileDetailsMapper);
     }
 
     @Test
+    void shouldClearSubmissionFilesWhenFormDetailsExist() {
+        when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
+        when(submissionRepository.read(anyString())).thenReturn(submission);
+        when(submission.getFormDetails()).thenReturn(formDetails);
+
+        final var actual = submissionService.clearSubmissionFiles(SUBMISSION_ID);
+
+        assertThat(actual.getId(), is(SUBMISSION_ID));
+        verify(formDetails).setFileDetailsList(null);
+        verify(submissionRepository).updateSubmission(argThat(s -> s.getFormDetails().equals(formDetails)));
+    }
+
+    @Test
+    void shouldClearSubmissionFilesWhenFormDetailsDoNotExist() {
+        when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
+        when(submissionRepository.read(anyString())).thenReturn(submission);
+        when(submission.getFormDetails()).thenReturn(null);
+
+        final var actual = submissionService.clearSubmissionFiles(SUBMISSION_ID);
+
+        assertThat(actual.getId(), is(SUBMISSION_ID));
+        verify(submissionRepository).updateSubmission(argThat(s -> s.getFormDetails() == null));
+    }
+
+    @Test
     void testUpdateSubmissionWithPaymentSessionsWhenOneExists() {
         // given
-        SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
-        SessionListApi sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
 
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentSessions(SUBMISSION_ID, sessionListApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission expected = submissionCaptor.getValue();
+        final var expected = submissionCaptor.getValue();
         assertThat(expected.getPaymentSessions(), is(sessionListApi));
     }
 
     @Test
     void testUpdateSubmissionWithPaymentSessionsWhenNoneExist() {
         // given
-        SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PAID.toString());
-        SessionListApi sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PAID.toString());
+        final var sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
 
         when(submission.getStatus()).thenReturn(SubmissionStatus.PAYMENT_REQUIRED);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentSessions(SUBMISSION_ID, sessionListApi);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission expected = submissionCaptor.getValue();
+        final var expected = submissionCaptor.getValue();
         assertThat(expected.getPaymentSessions(), is(sessionListApi));
         assertThat(expected.getStatus(), is(SubmissionStatus.PAYMENT_REQUIRED));
     }
@@ -547,39 +567,39 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionWithPaymentSessionsWhenPaymentReferenceNotFound() {
         // given
-        SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
-        SessionListApi sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
 
         when(submissionRepository.read(anyString())).thenReturn(null);
 
         // when
-        Executable actual =
+        final Executable actual =
             () -> submissionService.updateSubmissionWithPaymentSessions(SUBMISSION_ID,
                 sessionListApi);
 
         // then
-        SubmissionNotFoundException ex = assertThrows(SubmissionNotFoundException.class, actual);
-        assertEquals("Could not locate submission with id: [123]", ex.getMessage());
+        final var ex = assertThrows(SubmissionNotFoundException.class, actual);
+        assertEquals("Could not locate submission with id: [%s]".formatted(SUBMISSION_ID), ex.getMessage());
     }
 
     @Test
     void testUpdateSubmissionWithPaymentSessionsWhenIncorrectState() {
         // given
-        SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
-        SessionListApi sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var sessionListApi = new SessionListApi(Collections.singletonList(sessionApi));
 
         when(submission.getStatus()).thenReturn(SubmissionStatus.PROCESSING);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        Executable actual =
+        final Executable actual =
             () -> submissionService.updateSubmissionWithPaymentSessions(SUBMISSION_ID,
                 sessionListApi);
 
         // then
-        SubmissionIncorrectStateException ex =
+        final var ex =
             assertThrows(SubmissionIncorrectStateException.class, actual);
         assertEquals(EXPECTED_UPDATE_ERROR_MSG, ex.getMessage());
     }
@@ -593,13 +613,13 @@ class SubmissionServiceImplTest {
         when(timestampGenerator.generateTimestamp()).thenReturn(NOW.minusSeconds(1L))
             .thenReturn(NOW);
         // when
-        SubmissionResponseApi actual = submissionService.completeSubmission(SUBMISSION_ID);
+        final var actual = submissionService.completeSubmission(SUBMISSION_ID);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
         verify(timestampGenerator, times(2)).generateTimestamp();
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission expected = submissionCaptor.getValue();
+        final var expected = submissionCaptor.getValue();
         assertThat(expected.getStatus(), is(SubmissionStatus.SUBMITTED));
         assertThat(expected.getSubmittedAt(), is(NOW.minusSeconds(1L)));
         assertThat(expected.getLastModifiedAt(), is(NOW));
@@ -617,7 +637,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.completeSubmission(SUBMISSION_ID);
+        final var actual = submissionService.completeSubmission(SUBMISSION_ID);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -636,14 +656,14 @@ class SubmissionServiceImplTest {
         when(timestampGenerator.generateTimestamp()).thenReturn(NOW);
 
         // when
-        SubmissionIncorrectStateException exception =
+        final var exception =
             assertThrows(SubmissionIncorrectStateException.class, () -> submissionService.completeSubmission(SUBMISSION_ID));
-        assertEquals("Submission status for [123] wasn't in [SUBMITTED], couldn't update", exception.getMessage());
+        assertEquals("Submission status for [%s] wasn't in [SUBMITTED], couldn't update".formatted(SUBMISSION_ID), exception.getMessage());
 
         // then
         verify(timestampGenerator, times(2)).generateTimestamp();
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission updateSubmission = submissionCaptor.getValue();
+        final var updateSubmission = submissionCaptor.getValue();
         assertThat(updateSubmission.getStatus(), is(SubmissionStatus.SUBMITTED));
         assertThat(updateSubmission.getLastModifiedAt(), is(NOW));
         verify(validator).validate(submission);
@@ -658,7 +678,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.completeSubmission(SUBMISSION_ID);
+        final var actual = submissionService.completeSubmission(SUBMISSION_ID);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -674,7 +694,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        SubmissionResponseApi actual = submissionService.completeSubmission(SUBMISSION_ID);
+        final var actual = submissionService.completeSubmission(SUBMISSION_ID);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -692,10 +712,10 @@ class SubmissionServiceImplTest {
         doThrow(new SubmissionValidationException("bad data")).when(validator).validate(submission);
 
         // when
-        Executable actual = () -> submissionService.completeSubmission(SUBMISSION_ID);
+        final Executable actual = () -> submissionService.completeSubmission(SUBMISSION_ID);
 
         // then
-        SubmissionValidationException ex = assertThrows(SubmissionValidationException.class, actual);
+        final var ex = assertThrows(SubmissionValidationException.class, actual);
         assertEquals("bad data", ex.getMessage());
         verify(validator).validate(submission);
         verifyNoInteractions(emailService);
@@ -707,11 +727,11 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(null);
 
         // when
-        Executable actual = () -> submissionService.completeSubmission(SUBMISSION_ID);
+        final Executable actual = () -> submissionService.completeSubmission(SUBMISSION_ID);
 
         // then
-        SubmissionNotFoundException ex = assertThrows(SubmissionNotFoundException.class, actual);
-        assertEquals("Could not locate submission with id: [123]", ex.getMessage());
+        final var ex = assertThrows(SubmissionNotFoundException.class, actual);
+        assertEquals("Could not locate submission with id: [%s]".formatted(SUBMISSION_ID), ex.getMessage());
         verifyNoInteractions(validator);
         verifyNoInteractions(emailService);
     }
@@ -723,10 +743,10 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        Executable actual = () -> submissionService.completeSubmission(SUBMISSION_ID);
+        final Executable actual = () -> submissionService.completeSubmission(SUBMISSION_ID);
 
         // then
-        SubmissionIncorrectStateException ex = assertThrows(SubmissionIncorrectStateException.class, actual);
+        final var ex = assertThrows(SubmissionIncorrectStateException.class, actual);
         assertEquals(EXPECTED_COMPLETE_ERROR_MSG, ex.getMessage());
         verifyNoInteractions(validator);
         verifyNoInteractions(emailService);
@@ -740,12 +760,12 @@ class SubmissionServiceImplTest {
         when(submission.getId()).thenReturn(SUBMISSION_ID);
         when(formDetails.getFileDetailsList()).thenReturn(Collections.singletonList(fileDetails));
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionQueued(submission);
+        final var actual = submissionService.updateSubmissionQueued(submission);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission updateSubmission = submissionCaptor.getValue();
+        final var updateSubmission = submissionCaptor.getValue();
         assertThat(updateSubmission.getStatus(), is(SubmissionStatus.PROCESSING));
         assertThat(updateSubmission.getLastModifiedAt(), is(NOW));
 
@@ -757,7 +777,7 @@ class SubmissionServiceImplTest {
         when(submissionRepository.read(SUBMISSION_ID)).thenReturn(submission);
         when(submissionMapper.map(submission)).thenReturn(submissionApi);
         // when
-        SubmissionApi actual = submissionService.readSubmission(SUBMISSION_ID);
+        final var actual = submissionService.readSubmission(SUBMISSION_ID);
         // then
         assertEquals(submissionApi, actual);
         verify(submissionRepository).read(SUBMISSION_ID);
@@ -767,7 +787,7 @@ class SubmissionServiceImplTest {
     @Test
     void testReadSubmissionDoesNotMapMissingSubmission() {
         // when
-        SubmissionApi actual = submissionService.readSubmission(SUBMISSION_ID);
+        final var actual = submissionService.readSubmission(SUBMISSION_ID);
 
         // then
         assertNull(actual);
@@ -778,9 +798,9 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionBarcode() {
         // given
-        String barcode = "Y1234ABCD";
+        final var barcode = "Y1234ABCD";
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionBarcode(SUBMISSION_ID, barcode);
+        final var actual = submissionService.updateSubmissionBarcode(SUBMISSION_ID, barcode);
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
         verify(submissionRepository).updateBarcode(SUBMISSION_ID, barcode);
@@ -789,7 +809,7 @@ class SubmissionServiceImplTest {
     @Test
     void testUpdateSubmissionStatus() {
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionStatus(SUBMISSION_ID,
+        final var actual = submissionService.updateSubmissionStatus(SUBMISSION_ID,
                 SubmissionStatus.ACCEPTED);
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
@@ -815,7 +835,7 @@ class SubmissionServiceImplTest {
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(anyString())).thenReturn(submission);
         // when
-        SubmissionResponseApi actual = submissionService.updateSubmissionConfirmAuthorised(SUBMISSION_ID, true);
+        final var actual = submissionService.updateSubmissionConfirmAuthorised(SUBMISSION_ID, true);
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
         verify(submissionRepository).updateSubmission(argThat(s->s.getConfirmAuthorised().equals(Boolean.TRUE)));
@@ -824,39 +844,39 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenNotFound() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.FAILED);
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.FAILED);
 
         when(submissionRepository.read(SUBMISSION_ID)).thenReturn(null);
 
         // when
-        final SubmissionNotFoundException exception =
+        final var exception =
             assertThrows(SubmissionNotFoundException.class,
                 () -> submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID,
                     paymentClose));
 
         // then
-        assertThat(exception.getMessage(), is("Could not locate submission with id: [123]"));
+        assertThat(exception.getMessage(), is("Could not locate submission with id: [%s]".formatted(SUBMISSION_ID)));
         verifyNoMoreInteractions(submission);
     }
 
     @Test
     void updateSubmissionWithPaymentOutcomeWhenIncorrectStatus() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.FAILED);
-        final SessionApi paySession =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.FAILED);
+        final var paySession =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.PAYMENT_FAILED, paySession);
         when(submissionRepository.read(SUBMISSION_ID)).thenReturn(submission);
         when(submission.getId()).thenReturn(SUBMISSION_ID);
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
-        assertThat(submission.getPaymentSessions().get(0).getSessionStatus(),
+        assertThat(submission.getPaymentSessions().getFirst().getSessionStatus(),
             is(STATUS_FAILED));
         verifyNoMoreInteractions(submission, emailService);
 
@@ -865,9 +885,9 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenPaidBeforeCompletion() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.PAID);
-        final SessionApi paySession =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.PAID);
+        final var paySession =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.PAYMENT_REQUIRED, paySession);
         when(submissionRepository.read(SUBMISSION_ID)).thenReturn(submission);
@@ -875,16 +895,16 @@ class SubmissionServiceImplTest {
         when(timestampGenerator.generateTimestamp()).thenReturn(NOW);
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
-        assertThat(submission.getPaymentSessions().get(0).getSessionStatus(),
+        assertThat(submission.getPaymentSessions().getFirst().getSessionStatus(),
             is(STATUS_PAID));
         verify(timestampGenerator).generateTimestamp();
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission updateSubmission = submissionCaptor.getValue();
+        final var updateSubmission = submissionCaptor.getValue();
         assertThat(updateSubmission.getStatus(), is(SubmissionStatus.SUBMITTED));
         assertThat(updateSubmission.getLastModifiedAt(), is(NOW));
         verifyNoMoreInteractions(emailService);
@@ -894,21 +914,21 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenFailedBeforeCompletion() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.FAILED);
-        final SessionApi paySession =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.FAILED);
+        final var paySession =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.OPEN, paySession);
         when(submissionRepository.read(SUBMISSION_ID)).thenReturn(submission);
         when(submission.getId()).thenReturn(SUBMISSION_ID);
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         // then
         assertEquals(SUBMISSION_ID, actual.getId());
-        assertThat(submission.getPaymentSessions().get(0).getSessionStatus(),
+        assertThat(submission.getPaymentSessions().getFirst().getSessionStatus(),
             is(STATUS_FAILED));
         verifyNoMoreInteractions(submission, emailService);
     }
@@ -916,17 +936,17 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenPaymentSessionNotMatched() {
         // given
-        final PaymentClose paymentClose =
-            new PaymentClose(SESSION_ID + "X", PaymentClose.Status.FAILED);
-        final SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose =
+            new PaymentClose(PAY_SESSION_ID + "X", PaymentClose.Status.FAILED);
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.OPEN, sessionApi);
         when(submission.getStatus()).thenReturn(SubmissionStatus.OPEN);
         when(submissionRepository.read(SUBMISSION_ID)).thenReturn(submission);
 
         // when
-        final SubmissionIncorrectStateException exception =
+        final var exception =
             assertThrows(SubmissionIncorrectStateException.class,
                 () -> submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID,
                     paymentClose));
@@ -938,9 +958,9 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenSessionMatchedAndPaid() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.PAID);
-        SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.PAID);
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.PAYMENT_REQUIRED, sessionApi);
         when(submission.getId()).thenReturn(SUBMISSION_ID);
@@ -952,14 +972,14 @@ class SubmissionServiceImplTest {
         when(timestampGenerator.generateTimestamp()).thenReturn(NOW);
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         assertThat(actual.getId(), is(SUBMISSION_ID));
-        assertThat(submission.getPaymentSessions().get(0).getSessionStatus(), is(STATUS_PAID));
+        assertThat(submission.getPaymentSessions().getFirst().getSessionStatus(), is(STATUS_PAID));
         verify(timestampGenerator).generateTimestamp();
         verify(submissionRepository).updateSubmission(submissionCaptor.capture());
-        Submission updateSubmission = submissionCaptor.getValue();
+        final var updateSubmission = submissionCaptor.getValue();
         assertThat(updateSubmission.getStatus(), is(SubmissionStatus.SUBMITTED));
         assertThat(updateSubmission.getSubmittedAt(), is(NOW));
         assertThat(updateSubmission.getLastModifiedAt(), is(NOW));
@@ -968,9 +988,9 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenSessionMatchedAndFailed() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.FAILED);
-        SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.FAILED);
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.PAYMENT_REQUIRED, sessionApi);
         when(submissionRepository.read(anyString())).thenReturn(submission);
@@ -978,11 +998,11 @@ class SubmissionServiceImplTest {
 
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         assertThat(actual.getId(), is(SUBMISSION_ID));
-        assertThat(submission.getPaymentSessions().get(0).getSessionStatus(), is(STATUS_FAILED));
+        assertThat(submission.getPaymentSessions().getFirst().getSessionStatus(), is(STATUS_FAILED));
         verify(submissionRepository).read(SUBMISSION_ID);
         verify(submissionRepository).updateSubmission(argThat(s->s.getStatus() == SubmissionStatus.PAYMENT_FAILED));
     }
@@ -990,19 +1010,19 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenSessionMatchedAndCancelled() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.CANCELLED);
-        SessionApi sessionApi =
-                new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.CANCELLED);
+        final var sessionApi =
+                new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.PAYMENT_REQUIRED, sessionApi);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
                 submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         assertThat(actual.getId(), is(SUBMISSION_ID));
-        assertThat(submission.getPaymentSessions().get(0).getSessionStatus(), is(STATUS_CANCELLED));
+        assertThat(submission.getPaymentSessions().getFirst().getSessionStatus(), is(STATUS_CANCELLED));
         verify(submissionRepository, never()).updateSubmission(any(Submission.class));
         verify(submissionRepository).read(SUBMISSION_ID);
         verifyNoMoreInteractions(submissionRepository);
@@ -1012,19 +1032,19 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenPaymentAlreadyFailed() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.FAILED);
-        SessionApi sessionApi =
-                new SessionApi(SESSION_ID, SESSION_STATE, PaymentClose.Status.FAILED.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.FAILED);
+        final var sessionApi =
+                new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentClose.Status.FAILED.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.PAYMENT_FAILED, sessionApi);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
                 submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         assertThat(actual.getId(), is(SUBMISSION_ID));
-        assertThat(submission.getPaymentSessions().get(0).getSessionStatus(), is(STATUS_FAILED));
+        assertThat(submission.getPaymentSessions().getFirst().getSessionStatus(), is(STATUS_FAILED));
         verify(submissionRepository, never()).updateSubmission(any(Submission.class));
         verifyNoMoreInteractions(submissionRepository);
     }
@@ -1032,15 +1052,15 @@ class SubmissionServiceImplTest {
     @Test
     void updateSubmissionWithPaymentOutcomeWhenPaymentError() {
         // given
-        final PaymentClose paymentClose = new PaymentClose(SESSION_ID, PaymentClose.Status.ERROR);
-        SessionApi sessionApi =
-            new SessionApi(SESSION_ID, SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
+        final var paymentClose = new PaymentClose(PAY_SESSION_ID, PaymentClose.Status.ERROR);
+        final var sessionApi =
+            new SessionApi(PAY_SESSION_ID, PAY_SESSION_STATE, PaymentTemplate.Status.PENDING.toString());
 
         expectSubmissionWithPaymentSession(SubmissionStatus.PAYMENT_REQUIRED, sessionApi);
         when(submissionRepository.read(anyString())).thenReturn(submission);
 
         // when
-        final SubmissionResponseApi actual =
+        final var actual =
             submissionService.updateSubmissionWithPaymentOutcome(SUBMISSION_ID, paymentClose);
 
         assertThat(actual.getId(), is(SUBMISSION_ID));
@@ -1050,7 +1070,7 @@ class SubmissionServiceImplTest {
 
     private void expectSubmissionWithPaymentSession(final SubmissionStatus submissionStatus,
         final SessionApi sessionApi) {
-        final SessionListApi sessionListApi =
+        final var sessionListApi =
             new SessionListApi(Collections.singletonList(sessionApi));
 
         when(submission.getStatus()).thenReturn(submissionStatus);


### PR DESCRIPTION
## Brief description of the change(s)
>
Fix document removal failing after changing form type to FES-enabled form


## Jira ticket.

https://companieshouse.atlassian.net/browse/ASM-2728

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.



## Checklist
>
> Paste the ⭕️ emoji into the respective columns below. If a checklist item *is* applicable but you haven't done it, omit the emoji from both columns. You can optionally add notes to clear up ambiguity. Whitespace isn't important, as long as the emoji is within the cell `|  |` it will render correctly.

| Item                                                       | Done | Not applicable | Notes |
|:-----------------------------------------------------------|:----:|:--------------:|-------|
| Adhered to the CH style guide (required)                   |  ⭕️  |                |       |
| Added/updated logging                                      |  ⭕  |                |       |
| Written tests                                              |  ⭕  |                |       |
| Tested the new code in my local environment                |  ⭕  |                |       |
| Updated Docker/ECS configs                                 |  ⭕  |                |       |
| Updated release ticket description with any config changes |      |                |       |
| Updated release ticket to link to this work item           |      |                |       |
